### PR TITLE
fix(docs): update doc-html and doc-link examples

### DIFF
--- a/content/enterprise/guides/includes/embedded-documents.md
+++ b/content/enterprise/guides/includes/embedded-documents.md
@@ -27,7 +27,7 @@ An example of an includes return value:
       title: documentVersion.getTitle(),
       lead: 'Lead',
       byline: 'Byline',
-      link: 'https://example.com'
+      link: {href: 'https://example.com'}
     }
   }
 }

--- a/content/enterprise/reference-docs/content-model/directives.md
+++ b/content/enterprise/reference-docs/content-model/directives.md
@@ -85,7 +85,9 @@ type: 'html'
 component template attribute: `doc-html`
 
 ```js
-htmlDirective.setContent('<div>Moby Dick</div>')
+htmlDirective.setContent({
+  html: '<div>Moby Dick</div>'
+})
 ```
 
 
@@ -95,8 +97,13 @@ type: 'link'
 component template attribute: `doc-link`
 
 ```js
-linkDirective.setContent('http://www.test.com/')
+linkDirective.setContent({
+  href: 'http://www.test.com/',
+  target: '_blank'
+})
 ```
+
+Allowed values for `target`: '_blank', '_self', '_parent' or '_top'
 
 
 #### Include

--- a/content/enterprise/reference-docs/editor-api/document-drag-drop.md
+++ b/content/enterprise/reference-docs/editor-api/document-drag-drop.md
@@ -33,7 +33,9 @@ liEditor.dropHandlers.register({
 
     const {component, directiveName} = dropActions.createHtmlComponent()
     const directive = component.directives.get(directiveName)
-    directive.setContent(data.html)
+    directive.setContent({
+      html: data.html
+    })
 
     dropActions.dropLocation.insert(component)
 


### PR DESCRIPTION
## Changelog

Update occurrences of doc-link and doc-html to the new object format.