### PR TITLE
fix(import-api): update import docs

### DIFF
--- a/content/enterprise/guides/integrations/import-legacy-system-documents.md
+++ b/content/enterprise/guides/integrations/import-legacy-system-documents.md
@@ -8,14 +8,13 @@ menus:
 
 
 ## Foreword and import statistics
-As imports from old systems can contain millions of documents, it's important to correctly estimate the time needed to complete an import.
+Importing millions of documents from legacy systems into Livingdocs takes time. We observed these numbers:
+- 50k articles per hour
+- 100k - 300k images per hour
 
-As a rough number, you can assume to import ~ 50.000 articles and ~ 100.000 - 300.000 images per hour. Without the necessity to import images, you could import a lot more articles per hour.
+During these observations, memory usage was around ~4GB or RAM und 25Mbps of inbout and outbound bandwidth was used.
 
-This scenario assumes ~4 GB of RAM usage and a bandwidth of 25Mpbs inbound and outbound. 
-
-Of course, the Infrastructure can be scaled to support faster imports if that's necessary.
-
+If no images are imported, a lot more documents could be imported. 
 
 ## Custom document IDs
 

--- a/content/enterprise/guides/integrations/import-legacy-system-documents.md
+++ b/content/enterprise/guides/integrations/import-legacy-system-documents.md
@@ -6,9 +6,20 @@ menus:
     parent: Integrations
 ---
 
-{{< added-in release-2020-10 >}}
 
-## Motivation
+## Foreword and import statistics
+As imports from old systems can contain millions of documents, it's important to correctly estimate the time needed to complete an import.
+
+As a rough number, you can assume to import ~ 50.000 articles and ~ 100.000 - 300.000 images per hour. Without the necessity to import images, you could import a lot more articles per hour.
+
+This scenario assumes ~4 GB of RAM usage and a bandwidth of 25Mpbs inbound and outbound. 
+
+Of course, the Infrastructure can be scaled to support faster imports if that's necessary.
+
+
+## Custom document IDs
+
+{{< added-in release-2020-10 >}}
 
 During a migration of an existing system, it's best practice to migrate all entries of the old system into livingdocs.
 To ease the migration, we want to support user-defined identifiers, so a custom import script can reuse existing identifiers.
@@ -65,3 +76,18 @@ curl -k -X POST "https://edit.livingdocs.io/proxy/api/v1/import/documents" \
 }
 EOF
 ```
+
+## Custom publication dates
+
+{{< added-in release-2021-03 >}}
+
+When importing articles from legacy systems, you should be setting the `publicationDate`. The `publicationDate` can be found in the [public api documentation](https://edit.livingdocs.io/public-api) or [import api reference documentation]({{< ref "../../reference-docs/server/import-api.md" >}}).
+
+The `publicationDate` controls when an article has been published, updated and is important for the search to function properly.
+
+If an article has multiple publication dates and you want to keep a history of for example `created` and `updated`, we advise importing the same article twice.
+
+First import the article with the `publicationDate` containing the value of the first time an article was published.
+Then re-import the article and you basically would 'update' that article with a new `publicationDate`
+
+We save the `firstPublicationDate` of an article, so you could access both dates later on in your delivery and show when an article has been published initially and when it was updated.

--- a/content/enterprise/reference-docs/server-api/import_api.md
+++ b/content/enterprise/reference-docs/server-api/import_api.md
@@ -8,7 +8,7 @@ menus:
 ## `import`
 
 The Import API provides a possibility to programmatically create Documents. One popular use case is to funnel Documents from news aggregators into Livingdocs.
-Another very commen use case is importing old articles and having Livingdocs as the single sourth of truth.
+Another very commen use case is [importing old articles]({{< ref "../../guides/integrations/import-legacy-system-documents.md" >}}) and having Livingdocs as the single sourth of truth.
 The Import API saves your raw documents appropriately - to database and Elasticsearch.
 
 The Import function has the following signature
@@ -16,15 +16,6 @@ The Import function has the following signature
 ```js
 const importLog = await import({importJob, rawDocument, shouldCreateNew, updateCondition, userId})
 ```
-
-## Import speed
-As imports from old systems can contain millions of documents, it's important to correctly estimate the time needed to complete an import.
-
-As a rough number, you can assume to import ~ 50.000 articles and ~ 100.000 - 300.000 images per hour. Without the necessity to import images, you could import a lot more articles per hour.
-
-This scenario assumes ~4 GB of RAM usage and a bandwidth of 25Mpbs inbound and outbound. 
-
-Of course, the Infrastructure can be scaled to support faster imports if that's necessary.
 
 ### `importJob`
 
@@ -134,14 +125,3 @@ const lastImportLog = await getLastImportLog({projectId, channelId})
 ```
 
 
-
-## Importing articles from legacy systems
-When importing articles from legacy systems, you should be setting the `publicationDate`.
-The `publicationDate` controls when an article has been published, updated and is important for the search to function properly.
-
-If an article has multiple publication dates and you want to keep a history of for example `created` and `updated`, we advise importing the same article twice.
-
-First import the article with the `publicationDate` containing the value of the first time an article was published.
-Then re-import the article and you basically would 'update' that article with a new `publicationDate`
-
-We save the `firstPublicationDate` of an article, so you could access both dates later on in your delivery and show when an article has been published initially and when it was updated.

--- a/content/enterprise/reference-docs/server-api/import_api.md
+++ b/content/enterprise/reference-docs/server-api/import_api.md
@@ -28,7 +28,7 @@ const importLog = await import({importJob, rawDocument, shouldCreateNew, updateC
 * `channelid`: A `number` containing the Id of the Channel you want the Document to import to.
 * `contentType`: A `string`, the desired `contentType` of your Document.
 * `title`: A `string`, the title of your Document.
-* `publicationDate` A `string` containing an ISO date of when an article was published (`autoPublish` flag needs to be set as well)
+* `publicationDate` A `string` containing an ISO 8601 date time stamp of when an article was published (`autoPublish` flag needs to be set as well)
 
 ### `rawDocument`
 

--- a/content/enterprise/reference-docs/server-api/import_api.md
+++ b/content/enterprise/reference-docs/server-api/import_api.md
@@ -7,13 +7,24 @@ menus:
 
 ## `import`
 
-The Import API provides a possibility to programmatically create Documents. One popular use case is to funnel Documents from news aggregators into Livingdocs. The Import API saves your raw documents appropriately - to database and Elasticsearch.
+The Import API provides a possibility to programmatically create Documents. One popular use case is to funnel Documents from news aggregators into Livingdocs.
+Another very commen use case is importing old articles and having Livingdocs as the single sourth of truth.
+The Import API saves your raw documents appropriately - to database and Elasticsearch.
 
 The Import function has the following signature
 
 ```js
 const importLog = await import({importJob, rawDocument, shouldCreateNew, updateCondition, userId})
 ```
+
+## Import speed
+As imports from old systems can contain millions of documents, it's important to correctly estimate the time needed to complete an import.
+
+As a rough number, you can assume to import ~ 50.000 articles and ~ 100.000 - 300.000 images per hour. Without the necessity to import images, you could import a lot more articles per hour.
+
+This scenario assumes ~4 GB of RAM usage and a bandwidth of 25Mpbs inbound and outbound. 
+
+Of course, the Infrastructure can be scaled to support faster imports if that's necessary.
 
 ### `importJob`
 
@@ -26,6 +37,7 @@ const importLog = await import({importJob, rawDocument, shouldCreateNew, updateC
 * `channelid`: A `number` containing the Id of the Channel you want the Document to import to.
 * `contentType`: A `string`, the desired `contentType` of your Document.
 * `title`: A `string`, the title of your Document.
+* `publicationDate` A `string` containing an ISO date of when an article was published (`autoPublish` flag needs to be set as well)
 
 ### `rawDocument`
 
@@ -120,3 +132,16 @@ You can also fetch the latest ImportLog.
 ```js
 const lastImportLog = await getLastImportLog({projectId, channelId})
 ```
+
+
+
+## Importing articles from legacy systems
+When importing articles from legacy systems, you should be setting the `publicationDate`.
+The `publicationDate` controls when an article has been published, updated and is important for the search to function properly.
+
+If an article has multiple publication dates and you want to keep a history of for example `created` and `updated`, we advise importing the same article twice.
+
+First import the article with the `publicationDate` containing the value of the first time an article was published.
+Then re-import the article and you basically would 'update' that article with a new `publicationDate`
+
+We save the `firstPublicationDate` of an article, so you could access both dates later on in your delivery and show when an article has been published initially and when it was updated.


### PR DESCRIPTION
Server PR: https://github.com/livingdocsIO/livingdocs-server/pull/3569

### Changelog
Add `publicationDate` docs and some more numbers on estimations of how fast imports currently are.