### PR TITLE
Guide on how to generate Sitemaps & Feeds

### DIFF
--- a/content/enterprise/guides/sitemaps-and-feeds.md
+++ b/content/enterprise/guides/sitemaps-and-feeds.md
@@ -34,7 +34,7 @@ fastify.get('/sitemap.xml', async (req, rep) => {
   const res = await axios({
     method: 'get',
     headers: {Authorization: `Bearer ${livingdocsAccessToken}`},
-    url: `${serverUrl}/sitemaps/index?baseUrl=https://livingdocs.io/`,
+    url: `${serverUrl}/api/v1/sitemaps/index?baseUrl=https://livingdocs.io/`,
     responseType: 'stream'
   })
 
@@ -57,7 +57,7 @@ fastify.get('/sitemap.:date(*)', async (req, rep) => {
   const res = await axios({
     method: 'get',
     headers: {Authorization: `Bearer ${livingdocsAccessToken}`},
-    url: `${serverUrl}/sitemaps/entries?date=${req.params.date}&baseUrl=https://livingdocs.io/`,
+    url: `${serverUrl}/api/v1/sitemaps/entries?date=${req.params.date}&baseUrl=https://livingdocs.io/`,
     responseType: 'stream'
   })
 

--- a/content/enterprise/guides/sitemaps-and-feeds.md
+++ b/content/enterprise/guides/sitemaps-and-feeds.md
@@ -48,7 +48,7 @@ API-Scope: Public API token with `read-scope`
 
 **HTTP-API (GET)**
 
-`${serverUrl}/sitemaps/index?contentTypes=articles&baseUrl=https://livingdocs.io/entriesPerPage=20000&access_token=publicApiToken`
+`${serverUrl}/sitemaps/index?contentTypes=articles&baseUrl=https://livingdocs.io/entriesPerPage=20000`
 
 **Parameters**
 - **contentTypes** - comma separated list of content types you want to include in the Sitemap. Defaults to all content types if none are passed explicity
@@ -60,18 +60,26 @@ API-Scope: Public API token with `read-scope`
 - **entriesPerPage** - Customize how many Sitemap entries there will be per page. We recommend to not set anything and our default of 20000 entries will be applied.
   - `?entriesPerPage=20000` 
 
-**Return value**
+**Minimal delivery setup example**
 
-Returns an encoded XML string, use `decodeURIComponent()` to get a response equal to this example:
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <sitemap>
-    <loc>https://livingdocs.io/sitemap.2021-05.xml</loc>
-    <lastmod>2021-05-18T16:56:31.633Z</lastmod>
-  </sitemap>
-</sitemapindex>
+A minimal example that's implemented in a delivery could look like this:
+```js
+const fastify = require('fastify')({ logger: true })
+const livingdocsAccessToken = process.env.ACCESS_TOKEN
+const serverUrl = 'https://edit.livingdocs.io/proxy/api'
+
+fastify.get('/sitemap.xml', async (req, rep) => {
+  const res = await axios({
+    method: 'get',
+    headers: {Authorization: `Bearer ${livingdocsAccessToken}`},
+    url: `${serverUrl}/sitemaps/index?baseUrl=https://livingdocs.io/`,
+    responseType: 'stream'
+  })
+
+  return res.data
+})
 ```
+
 
 **Note**
 
@@ -101,7 +109,7 @@ API-Scope: Public API token with `read-scope`
 
 **HTTP-API (GET)**
 
-`${serverUrl}/sitemaps/entries?date=2021-05&contentTypes=articles&baseUrl=https://livingdocs.io/&entriesPerPage=20000&access_token=publicApiToken`
+`${serverUrl}/sitemaps/entries?date=2021-05&contentTypes=articles&baseUrl=https://livingdocs.io/&entriesPerPage=20000`
 
 **Parameters**
 - **date** - for the specific month matching the schema from the sitemap index file
@@ -116,14 +124,22 @@ API-Scope: Public API token with `read-scope`
 - **entriesPerPage** - Customize how many Sitemap entries there will be per page. We recommend to not set anything and our default of 20000 entries will be applied.
   - `?entriesPerPage=20000` 
 
-**Return value**
+**Minimal delivery setup example**
 
-Returns an encoded XML string, use `decodeURIComponent()` to get a response equal to this example:
-```xml
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://www.livingdocs.io/category/title-li.1</loc>
-    <lastmod>2021-05-01T04:56:50.276Z</lastmod>
-  </url>
-</urlset>
+A minimal example that's implemented in a delivery could look like this:
+```js
+const fastify = require('fastify')({ logger: true })
+const livingdocsAccessToken = process.env.ACCESS_TOKEN
+const serverUrl = 'https://edit.livingdocs.io/proxy/api'
+
+fastify.get('/sitemap.:date(*)', async (req, rep) => {
+  const res = await axios({
+    method: 'get',
+    headers: {Authorization: `Bearer ${livingdocsAccessToken}`},
+    url: `${serverUrl}/sitemaps/entries?date=${req.params.date}&baseUrl=https://livingdocs.io/`,
+    responseType: 'stream'
+  })
+
+  return res.data
+})
 ```

--- a/content/enterprise/guides/sitemaps-and-feeds.md
+++ b/content/enterprise/guides/sitemaps-and-feeds.md
@@ -67,7 +67,7 @@ fastify.get('/sitemap.:date(*)', async (req, rep) => {
 
 ## **Feeds**
 
-Feeds are highly customizeable and no there is no 'one-fits-it-all' solution. We will still outline a way to integrate feeds using one of our helper methods for Feeds that builds up on the RSS 2.0 Specification
+Feeds are highly customizable and no there is no 'one-fits-it-all' solution. We will still outline a way to integrate feeds using one of our helper methods for Feeds that builds upon the RSS 2.0 Specification
 
 **Server Downstream**
 You will need to add your own HTTP-API.
@@ -116,7 +116,6 @@ module.exports = {
 // Setup the Feature - ./feeds/feeds_controller.js
 module.exports = ({feedsApi}) => {
   return {
-    // retrieve an article
     async getFeed (req, res) {
       const {channelId, projectId} = req.verifiedToken
       const feed = await feedsApi.getFeed({channelId, projectId})
@@ -131,11 +130,13 @@ module.exports = ({feedsApi}) => {
 module.exports = ({searchManager, sitemapsApi}) => {
   return {
     async getFeed ({projectId, channelId}) {
+      // gather the latest published documents with the 'article' contentType
       const res = await searchManager.searchPublications({
         projectId: projectId,
         channelId: channelId,
         contentTypes: ['article']
       })
+      // render the XML
       const xml = sitemapsApi.renderFeedXml({
         title: 'Feed title',
         description: 'Feed description',

--- a/content/enterprise/guides/sitemaps-and-feeds.md
+++ b/content/enterprise/guides/sitemaps-and-feeds.md
@@ -167,6 +167,12 @@ Note: This still result still needs to be consumed in the delivery, similar to t
 ## **Live Delivery Setup**
 This live demo of a minimal delivery runs against a real livingdocs instance.
 
+You can explore the following routes in the example
+- `/robots.txt`
+- `/sitemap.xml`
+- `/sitemap.2021-06.xml`
+- `/feed.xml`
+
 <h3 style="text-align: center;">Interactive minimal delivery example</h3>
 <script src="https://embed.runkit.com"></script>
 <div id="my-element"></div>
@@ -189,19 +195,21 @@ fastify.get("/", async (req, rep) => rep.redirect("/sitemap.xml"));
 \ 
 // set up a robots.txt, linking to the Sitemap and Feed
 fastify.get("/robots.txt", (req, rep) => {
-    return \`
-Sitemap: /feed.xml
+    return \`Sitemap: /feed.xml
 Sitemap: /sitemap.xml
 \`
 })
 \ 
+// use your own credentials to create a sitemap!
+const accessToken = process.env.ACCESS_TOKEN
+const serverUrl = process.env.SERVER_URL
+\ 
 // example route to retrieve the Sitemap index file
 fastify.get("/sitemap.xml", async (req, rep) => {
-  console.log({ token: process.env.ACCESS_TOKEN, url: process.env.SERVER_URL });
   const res = await axios({
     method: "get",
-    headers: { Authorization: "Bearer " + process.env.ACCESS_TOKEN },
-    url: process.env.SERVER_URL + "/api/v1/sitemaps/index?baseUrl=/",
+    headers: { Authorization: "Bearer " + accessToken },
+    url: serverUrl + "/api/v1/sitemaps/index?baseUrl=https://livingdocs.io",
     responseType: "text",
   });
   return res.data;
@@ -209,13 +217,12 @@ fastify.get("/sitemap.xml", async (req, rep) => {
 \ 
 // example route to retrieve the Sitemap entries file
 fastify.get("/sitemap.:date", async (req, rep) => {
-  console.log(req.params);
   const res = await axios({
     method: "get",
-    headers: { Authorization: "Bearer " + process.env.ACCESS_TOKEN },
+    headers: { Authorization: "Bearer " + accessToken },
     url:
-      process.env.SERVER_URL +
-      "/api/v1/sitemaps/entries?baseUrl=/&date=" +
+      serverUrl +
+      "/api/v1/sitemaps/entries?baseUrl=https://livingdocs.io/&date=" +
       req.params.date.split(".")[0],
     responseType: "text",
   });

--- a/content/enterprise/guides/sitemaps-and-feeds.md
+++ b/content/enterprise/guides/sitemaps-and-feeds.md
@@ -105,7 +105,7 @@ module.exports = ({searchManager, sitemapsApi}) => {
         language: 'de',
         copyright: 'Feed copyright',
         link: 'https://livingdocs.io/',
-        pubDate: new Date(),
+        pubDate: res.results[0]?.createdAt,
         lastBuildDate: new Date(),
         image: {
           url: 'https://example.com/foo',
@@ -119,7 +119,7 @@ module.exports = ({searchManager, sitemapsApi}) => {
           return {
             title: 'document title',
             description: 'document description',
-            pubDate: new Date(doc.createdAt),
+            pubDate: doc.createdAt,
             link: `https://livingdocs.io/article/${doc.documentId}`
           }
         })

--- a/content/enterprise/guides/sitemaps-and-feeds.md
+++ b/content/enterprise/guides/sitemaps-and-feeds.md
@@ -1,0 +1,129 @@
+---
+title: Sitemaps & Feeds
+tags: [sitemaps, feeds, sitemap, feed, guides]
+menus:
+  guides:
+---
+
+# Sitemaps
+
+{{< added-in release-2021-06 >}}
+
+The `livingdocs-server` ships with a set of APIs to automatically create Sitemaps. 
+
+In your delivery you will need to link the Sitemap in a `robots.txt` file and set up the routing to call our APIs.
+
+
+## **Sitemaps Index**
+**You need to make sure to set up routes in your delivery calling the HTTP Endpoint**
+
+The Sitemap index file points to Sitemap entry files that will contain 20000 entries by default.
+
+The Sitemaps contain up to 20000 entries per month and will be split if there are more.
+
+```xml
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://www.livingdocs.io/sitemap.2020-01.xml</loc>
+    <lastmod>2020-01-31T22:54:23.125Z</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.livingdocs.io/sitemap.2020-02.xml</loc>
+    <lastmod>2020-02-29T21:07:31.544Z</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.livingdocs.io/sitemap.2020-02.2.xml</loc>
+    <lastmod>2020-02-29T21:07:31.544Z</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>https://www.livingdocs.io/sitemap.2020-02.3.xml</loc>
+    <lastmod>2020-02-29T21:07:31.544Z</lastmod>
+  </sitemap>
+</sitemapindex>
+```
+
+**Scope**
+
+API-Scope: Public API token with `read-scope`
+
+**HTTP-API (GET)**
+
+`${serverUrl}/sitemaps/index?contentTypes=articles&baseUrl=https://livingdocs.io/entriesPerPage=20000&access_token=publicApiToken`
+
+**Parameters**
+- **contentTypes** - comma separated list of content types you want to include in the Sitemap. Defaults to all content types if none are passed explicity
+  - `?contentTypes=regular,pages`
+  
+- **baseUrl** - base url of the delivery host
+  - `?baseUrl=https://livingdocs.io/`
+
+- **entriesPerPage** - Customize how many Sitemap entries there will be per page. We recommend to not set anything and our default of 20000 entries will be applied.
+  - `?entriesPerPage=20000` 
+
+**Return value**
+
+Returns an encoded XML string, use `decodeURIComponent()` to get a response equal to this example:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://livingdocs.io/sitemap.2021-05.xml</loc>
+    <lastmod>2021-05-18T16:56:31.633Z</lastmod>
+  </sitemap>
+</sitemapindex>
+```
+
+**Note**
+
+_Several Sitemaps for various content types could be created if they are individually linked in the robots.txt file_
+
+## **Sitemap entries**
+**You need to make sure to set up routes in your delivery passing the date query param to our HTTP Endpoint**
+
+The Sitemap entry files are consist of the documents in a set of 20000 by default. 
+
+```xml
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.livingdocs.io/category/title-li.1</loc>
+    <lastmod>2021-05-01T04:56:50.276Z</lastmod>
+  </url>
+  <url>
+    <loc>https://www.livingdocs.io/category/title-li.2</loc>
+    <lastmod>2021-05-01T05:35:32.920Z</lastmod>
+  </url>
+</urlset>
+```
+
+**Scope**
+
+API-Scope: Public API token with `read-scope`
+
+**HTTP-API (GET)**
+
+`${serverUrl}/sitemaps/entries?date=2021-05&contentTypes=articles&baseUrl=https://livingdocs.io/&entriesPerPage=20000&access_token=publicApiToken`
+
+**Parameters**
+- **date** - for the specific month matching the schema from the sitemap index file
+  - `?date=2021-05`
+  
+- **contentTypes** - comma separated list of content types you want to include in the Sitemap. Defaults to all content types if none are passed explicity
+  - `?contentTypes=regular,pages`
+  
+- **baseUrl** - base url of the delivery host
+  - `?baseUrl=https://livingdocs.io/`
+
+- **entriesPerPage** - Customize how many Sitemap entries there will be per page. We recommend to not set anything and our default of 20000 entries will be applied.
+  - `?entriesPerPage=20000` 
+
+**Return value**
+
+Returns an encoded XML string, use `decodeURIComponent()` to get a response equal to this example:
+```xml
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.livingdocs.io/category/title-li.1</loc>
+    <lastmod>2021-05-01T04:56:50.276Z</lastmod>
+  </url>
+</urlset>
+```

--- a/content/enterprise/guides/sitemaps-and-feeds.md
+++ b/content/enterprise/guides/sitemaps-and-feeds.md
@@ -241,7 +241,7 @@ fastify.get("/feed.xml", (req, rep) => {
     <item>
         <title>Foo story title</title>
         <description>Foo story description</description>
-        <link>https://ivingdocs.io/foo-article</link>
+        <link>https://livingdocs.io/foo-article</link>
         <pubDate>Wed, 16 Jun 2021 11:05:53 GMT</pubDate>
     </item>
 </channel>

--- a/content/enterprise/guides/sitemaps-and-feeds.md
+++ b/content/enterprise/guides/sitemaps-and-feeds.md
@@ -209,7 +209,7 @@ fastify.get("/sitemap.xml", async (req, rep) => {
   const res = await axios({
     method: "get",
     headers: { Authorization: "Bearer " + accessToken },
-    url: serverUrl + "/api/v1/sitemaps/index?baseUrl=https://livingdocs.io",
+    url: serverUrl + "/api/v1/sitemaps/index?baseUrl=https://livingdocs.io/",
     responseType: "text",
   });
   return res.data;

--- a/content/enterprise/guides/sitemaps-and-feeds.md
+++ b/content/enterprise/guides/sitemaps-and-feeds.md
@@ -88,7 +88,7 @@ module.exports = function (feature, server) {
     searchManager,
     sitemapsApi
   })
-  
+
   const controller = require('./feeds_controller')({feedsApi})
   const routes = require('./feeds_routes')
 
@@ -165,6 +165,38 @@ module.exports = ({searchManager, sitemapsApi}) => {
     }
   }
 }
+```
+
+**Result**
+
+Given valid published articles in Livingdocs, the feed should be created:
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+<channel>
+  <title>Feed title</title>
+  <description>Alle Artikel von Livingdocs</description>
+  <language>de</language>
+  <copyright>copy-foo-right</copyright>
+  <image>
+    <url>https://example.com/foo-image</url>
+    <title>foo-image-title</title>
+    <description>some description for this image</description>
+    <link>https://example.com/foo-image</link>
+    <width>144</width>
+    <height>400</height>
+  </image>
+  <pubDate>Wed, 19 May 2021 14:55:06 GMT</pubDate>
+  <lastBuildDate>Wed, 19 May 2021 14:55:06 GMT</lastBuildDate>
+  <link>https://livingdocs.io/</link>
+  <item>
+    <title>foo item title</title>
+    <description>foo item description</description>
+    <link>https://livingdocs.io/article/1</link>
+    <pubDate>Tue, 01 Jan 2030 00:00:00 GMT</pubDate>
+  </item>
+</channel>
+</rss>
 ```
 
 **Minimal delivery setup example**

--- a/content/enterprise/guides/sitemaps-and-feeds.md
+++ b/content/enterprise/guides/sitemaps-and-feeds.md
@@ -5,73 +5,35 @@ menus:
   guides:
 ---
 
+{{< added-in release-2021-06 >}}
 # Sitemaps
 
-{{< added-in release-2021-06 >}}
 
-The `livingdocs-server` ships with a set of APIs to automatically create Sitemaps. The full API specification can be found in our public API documentation at https://edit.livingdocs.io/public-api
+The `livingdocs-server` ships with a set of APIs to automatically create sitemaps. The full (public) API specification can be found in our public API documentation at https://edit.livingdocs.io/public-api
 
 This guide will focus on the setup of Sitemaps within a delivery and the downstream customizations that need to be done to set up Feeds.
 
-## Robots.txt
-**Minimal delivery setup example**
+__We provide a running minimal delivery, in the "Live Delivery Setup" section__
+## **Robots.txt**
+You will need to link the Sitemap and Feed in the robots.txt of your delivery
 ```
 Sitemap: https://www.livingdocs.io/sitemap.xml
 Sitemap: https://www.livingdocs.io/feed.xml
 ```
 
-## **Sitemaps Index**
-
-
-**Minimal delivery setup example**
-
-```js
-const fastify = require('fastify')({ logger: true })
-const livingdocsAccessToken = process.env.ACCESS_TOKEN
-const serverUrl = 'https://edit.livingdocs.io/proxy/api'
-
-fastify.get('/sitemap.xml', async (req, rep) => {
-  const res = await axios({
-    method: 'get',
-    headers: {Authorization: `Bearer ${livingdocsAccessToken}`},
-    url: `${serverUrl}/api/v1/sitemaps/index?baseUrl=https://livingdocs.io/`,
-    responseType: 'stream'
-  })
-
-  return res.data
-})
-```
-
-_Note: Several Sitemaps for various content types could be created if they are individually linked in the robots.txt file_
-
+## **Sitemap index**
+The Sitemap index points to individual months, that contain all the actual entries of a Sitemap.
+Several Sitemaps for various content types could be created if they are individually linked in the robots.txt file.
 ## **Sitemap entries**
 
-**Minimal delivery setup example**
-
-```js
-const fastify = require('fastify')({ logger: true })
-const livingdocsAccessToken = process.env.ACCESS_TOKEN
-const serverUrl = 'https://edit.livingdocs.io/proxy/api'
-
-fastify.get('/sitemap.:date(*)', async (req, rep) => {
-  const res = await axios({
-    method: 'get',
-    headers: {Authorization: `Bearer ${livingdocsAccessToken}`},
-    url: `${serverUrl}/api/v1/sitemaps/entries?date=${req.params.date}&baseUrl=https://livingdocs.io/`,
-    responseType: 'stream'
-  })
-
-  return res.data
-})
-```
+The Sitemap entries follow the schema `sitemap.YYYY-MM.xml` or if it has more than the suggested limit of entries it will be split into a separate file such as `sitemap.YYYY-MM.2.xml`. We suggest keeping the limits the livingdocs API provides.
 
 ## **Feeds**
 
-Feeds are highly customizable and no there is no 'one-fits-it-all' solution. We will still outline a way to integrate feeds using one of our helper methods for Feeds that builds upon the RSS 2.0 Specification
+Feeds are highly customizable and no there is no 'one-fits-it-all' solution. We will still outline a way to integrate Feeds using one of our helper methods for Feeds that builds upon the RSS 2.0 Specification
 
 **Server Downstream**
 You will need to add your own HTTP-API.
-
 
 ```js
 // Register the feature
@@ -169,9 +131,10 @@ module.exports = ({searchManager, sitemapsApi}) => {
 ```
 
 **Result**
+Note: This still result still needs to be consumed in the delivery, similar to the already implemented examples in the live delivery example in the next section.
 
-Given valid published articles in Livingdocs, the feed should be created:
 ```xml
+<!-- example payload of the new downstream Feeds endpoint -->
 <?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0">
 <channel>
@@ -200,6 +163,84 @@ Given valid published articles in Livingdocs, the feed should be created:
 </rss>
 ```
 
-**Minimal delivery setup example**
 
+## **Live Delivery Setup**
+This live demo of a minimal delivery runs against a real livingdocs instance.
 
+<h3 style="text-align: center;">Interactive minimal delivery example</h3>
+<script src="https://embed.runkit.com"></script>
+<div id="my-element"></div>
+<script>var notebook = RunKit.createNotebook({
+    // the parent element for the new notebook
+    element: document.getElementById("my-element"),
+    // (Read-only) access token is from a random livingdocs demo project running against development.
+    environment: [{
+      name: 'ACCESS_TOKEN', 
+      value: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzY29wZSI6InB1YmxpYy1hcGk6cmVhZCIsIm5hbWUiOiJBcGktdG9rZW4iLCJwcm9qZWN0SWQiOjEzMSwiY2hhbm5lbElkIjoxMzEsInR5cGUiOiJjbGllbnQiLCJqdGkiOiI2OTRlY2FmYi0wZGJlLTQ3MmQtOTk2ZC01ZjAwMTMwZTJiYWUiLCJjb2RlIjoiNjk0ZWNhZmItMGRiZS00NzJkLTk5NmQtNWYwMDEzMGUyYmFlIiwiaWF0IjoxNjIzNzYwMjAzfQ.X9IZpvThY-F7IWekGlDA1CX56ZdAMWwidx3QRZtTEPk'},
+      {name: 'SERVER_URL', value: 'https://develop.livingdocs.io/proxy'}
+    ],
+    nodeVersion: '16',
+    mode: 'endpoint',
+    source: `const axios = require("axios");
+const fastify = require("fastify")({ logger: true });
+\ 
+// redirect for demo purposes
+fastify.get("/", async (req, rep) => rep.redirect("/sitemap.xml"));
+\ 
+// set up a robots.txt, linking to the Sitemap and Feed
+fastify.get("/robots.txt", (req, rep) => {
+    return \`
+Sitemap: /feed.xml
+Sitemap: /sitemap.xml
+\`
+})
+\ 
+// example route to retrieve the Sitemap index file
+fastify.get("/sitemap.xml", async (req, rep) => {
+  console.log({ token: process.env.ACCESS_TOKEN, url: process.env.SERVER_URL });
+  const res = await axios({
+    method: "get",
+    headers: { Authorization: "Bearer " + process.env.ACCESS_TOKEN },
+    url: process.env.SERVER_URL + "/api/v1/sitemaps/index?baseUrl=/",
+    responseType: "text",
+  });
+  return res.data;
+});
+\ 
+// example route to retrieve the Sitemap entries file
+fastify.get("/sitemap.:date", async (req, rep) => {
+  console.log(req.params);
+  const res = await axios({
+    method: "get",
+    headers: { Authorization: "Bearer " + process.env.ACCESS_TOKEN },
+    url:
+      process.env.SERVER_URL +
+      "/api/v1/sitemaps/entries?baseUrl=/&date=" +
+      req.params.date.split(".")[0],
+    responseType: "text",
+  });
+  return res.data;
+});
+\ 
+// hardcoded mock output, as Feeds need to be implemented in the downstream server
+fastify.get("/feed.xml", (req, rep) => {
+  return \`<rss version="2.0">
+<channel>
+    <title>Livingdocs RSS Feeds Demo</title>
+    <description>Livingdocs RSS Feeds Demo</description>
+    <pubDate>Wed, 16 Jun 2021 11:05:53 GMT</pubDate>
+    <lastBuildDate>Wed, 16 Jun 2021 11:11:53 GMT</lastBuildDate>
+    <link>https://livingdocs.io/</link>
+    <item>
+        <title>Foo story title</title>
+        <description>Foo story description</description>
+        <link>https://ivingdocs.io/foo-article</link>
+        <pubDate>Wed, 16 Jun 2021 11:05:53 GMT</pubDate>
+    </item>
+</channel>
+</rss> 
+\`;
+});
+await fastify.listen(3000);
+`
+})</script>


### PR DESCRIPTION
# Relations
Server-PR: https://github.com/livingdocsIO/livingdocs-server/pull/3664
Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/4277

# Motivation
As we shipped the new Sitemaps API, we want to provide some guidelines on how to integrate the Sitemaps and Feeds for a delivery.