### PR TITLE
chore(npm): Make start script cross-platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "livingdocs",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -14,6 +15,9 @@
         "glob": "^7.1.6",
         "htmlparser2": "^6.0.0",
         "lunr": "^2.3.9"
+      },
+      "devDependencies": {
+        "opener": "^1.5.2"
       }
     },
     "node_modules/balanced-match": {
@@ -167,6 +171,15 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/path-is-absolute": {
@@ -337,6 +350,12 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,9 +11,12 @@
     "htmlparser2": "^6.0.0",
     "lunr": "^2.3.9"
   },
+  "devDependencies": {
+    "opener": "^1.5.2"
+  },
   "scripts": {
     "build": "./bin/build.sh",
-    "start": "open http://localhost:1313 && exec hugo serve"
+    "start": "opener http://localhost:1313 && exec hugo serve"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This ends up adding quite a few packages. Should I look for another way?

The old command would open the browser before the server started, requiring a page refresh. Now it waits for the port to respond before opening the browser.