### PR TITLE
feat: Add revoke media page and events

### DIFF
--- a/content/enterprise/guides/revoke-media.md
+++ b/content/enterprise/guides/revoke-media.md
@@ -1,0 +1,47 @@
+---
+title: Revoke Media
+description: Handle the revoke event to complete the removal of media
+menu: guides
+tags: [guides]
+---
+
+The Livingdocs server handles the basic functionality of revoking media - removing the asset(s) from storage, removing the media library entry from the dashboard, and updating the media library entry state.
+It is likely that each customer will have their own requirements for additional steps required to complete the revoke process based on their server configuration and editorial processes.
+These steps may include:
+- clearing caches
+- regenerating pages
+- replacing the media with a placeholder
+- sending an email notification
+
+To be as flexible as possible we have provided a server event and a webhook, both named `mediaLibraryEntry.revoke`, which the downstream server can subscribe to.
+
+## Example
+
+### imgix cache purge
+
+As is common for many content delivery networks (CDN), imgix will cache your source image for up to one year on its own servers.
+After the Livingdocs server deletes the asset from storage it could still take days, weeks or even months before the image is removed from the CDN.
+In order to avoid this delay it is important to instruct imgix to clear it's cache for the asset and serve the latest version, or in this case a missing/broken image.
+Below is an example of simple purge request sent to imgix using the `axios` library and an API key for authorization:
+
+```js
+liServer.events.subscribe('mediaLibraryEntry.revoke', async (event, {mediaLibraryEntry}) => {
+  // Handle errors for async event listeners, because an unhandled rejection will stop the server process!
+  try {
+    const imageService = framework.imageServices.get('imgix')
+    const url = imageService.getUrl(mediaLibraryEntry.asset.url)
+    const response = await axios({
+      method: 'post',
+      url: 'https://api.imgix.com/api/v1/purge',
+      validateStatus: null,
+      headers: {Authorization: `Bearer ${process.env.IMGIX_API_KEY}`},
+      data: {data: {attributes: {url}, type: 'purges'}}
+    })
+    if (response.status !== 200) {
+      liServer.log.error(`Could not purge cache for media library entry "${mediaLibraryEntry.id}"`)
+    }
+  } catch (error) {
+    liServer.log.error(error)
+  }
+})
+```

--- a/content/enterprise/reference-docs/server-api/events.md
+++ b/content/enterprise/reference-docs/server-api/events.md
@@ -103,8 +103,9 @@ The following lists all events, before the comma, the name of the event and behi
 
 - mediaLibraryEntry {{< added-in release-2020-12 >}}
   - mediaLibraryEntry.create, `(eventName, {userId, projectId, mediaLibraryEntry})`
-  - mediaLibraryEntry.update, `(eventName, {userId, projectId, id})`
+  - mediaLibraryEntry.update, `(eventName, {userId, projectId, id, changes})`
   - mediaLibraryEntry.archive, `(eventName, {userId, projectId, id})`
+  - mediaLibraryEntry.revoke, `(eventName, {userId, projectId, mediaLibraryEntry})`
 
 - project
   - project.create, `(eventName, {project})`

--- a/content/enterprise/reference-docs/server-configuration/webhooks.md
+++ b/content/enterprise/reference-docs/server-configuration/webhooks.md
@@ -11,6 +11,8 @@ menus:
   - `mediaLibraryEntry.create`
   - `mediaLibraryEntry.archive`
   - `mediaLibraryEntry.update`
+- One new webhook added in `release-2021-09`
+  - `mediaLibraryEntry.revoke`
 
 Webhooks are registered HTTP endpoints that are called on specific events.
 You can configure multiple webhooks that are called on only one or multiple events.
@@ -65,6 +67,7 @@ webhooks: {
       },
       'mediaLibraryEntry.create',
       'mediaLibraryEntry.archive',
+      'mediaLibraryEntry.revoke',
       'mediaLibraryEntry.update'
     ]
   }
@@ -168,6 +171,19 @@ The payload sent to your webhook endpoints looks like this. The `deliveryId` is 
   "mediaId": "PNIi08x4UdEA"
 }
 ```
+
+`mediaLibraryEntry.revoke`
+```json
+{
+  "event": "mediaLibraryEntry.revoke",
+  "deliveryId": "J1FrTJTNKKRoGmjBlQ3_e",
+  "projectId": 3,
+  "projectHandle": "service",
+  "webhookHandle": "handle",
+  "mediaId": "PNIi08x4UdEA"
+}
+```
+
 ## Securing your webhooks
 If you have defined a `secret` for your webhook, Livingdocs uses this to create a signature of the payload and sends it with the request in the HTTP header `x-livingdocs-signature`.
 The signature is created using HMAC-SHA256 and will be sent in `x-livingdocs-signature` in the form `sha256=<hex digest>` for example `sha256=d8a47af83666a771d57117aa28ef8d3243a3de43`.


### PR DESCRIPTION
Relations:
  - Issue: https://3.basecamp.com/4910529/buckets/19620057/documents/3884808654
  - Related PR's:
    - https://github.com/livingdocsIO/livingdocs-server/pull/3809
    - https://github.com/livingdocsIO/livingdocs-editor/pull/4516

Remaining questions:
1. Should we make a media library section in the guides, split the existing content and add this as another page there?
2. Alternatively, could this be a workflow where we add suggestions about reviewing references and replacing the image?
3. Should I add some more examples? If so, what?