### PR TITLE
Use hugo alias to circumvent permanent redirect

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,6 +5,8 @@ renderEditButton: false
 renderSummaries: false
 renderTOC: false
 outputs: [html, rss, SearchIndex]
+aliases:
+  - "/enterprise"
 ---
 
 <!-- ## Learn important concepts and features


### PR DESCRIPTION
## Changelog

- 🔧 Use hugo alias for the startpage to redirect from '/enterprise'