### PR TITLE
Deal with permanent redirects to /enterprise

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -4,43 +4,6 @@ description: Technical documentation for Livingdocs.
 renderEditButton: false
 renderSummaries: false
 renderTOC: false
-outputs: [html, rss, SearchIndex]
-aliases:
-  - "/enterprise"
 ---
 
-<!-- ## Learn important concepts and features
-
-In our [learn]() section you can find an introduction to the most important concepts of Livingdocs which will make using and configuring our product much easier. -->
-
-
-## Evaluation
-
-If you are already in contact with us and have access to our repositories we recommend our [Evaluation Guide]({{< ref "/evaluation/getting-started.md" >}}) to set up Livingdocs locally (in case you haven't you can contact us at contact@livingdocs.io).
-
-
-## Having a first look on edit.livingdocs.io?
-
-You can check out Livingdocs via our service at [edit.livingdocs.io](https://edit.livingdocs.io). This way you do not have to set up anything locally and can see quickly how our editor and our REST Api work. On the service you will be set up with a preconfigured project.
-
-There is a separate documentation to get you started quickly with our service at [developers.livingdocs.io](https://developers.livingdocs.io).
-
-
-## Guides
-
-If you would like to get a specific task done head over to the [guides]({{< ref "guides" >}}) section.
-
-
-## Operations
-
-To see common setups, cloud deployments, required services and monitoring options refer to our [devops section]({{< ref "operations/self-hosting.md" >}}).
-
-
-{{< img src="illustration.png" alt="Livingdocs in a Box" >}}
-
-
-## Feedback
-
-Please let us know about gaps or errors in our documentation at [documentation@livingdocs.io](mailto:documentation@livingdocs.io) or you can do a pull request on https://github.com/livingdocsIO/livingdocs.
-
-(If you are viewing this documentation on our Github repository, there is a new nicer view of it at https://docs.livingdocs.io)
+[Home]({{< ref "/home" >}})

--- a/content/home.md
+++ b/content/home.md
@@ -1,0 +1,43 @@
+---
+title: Livingdocs Documentation
+description: Technical documentation for Livingdocs.
+renderEditButton: false
+renderSummaries: false
+renderTOC: false
+---
+
+<!-- ## Learn important concepts and features
+
+In our [learn]() section you can find an introduction to the most important concepts of Livingdocs which will make using and configuring our product much easier. -->
+
+
+## Evaluation
+
+If you are already in contact with us and have access to our repositories we recommend our [Evaluation Guide]({{< ref "/evaluation/getting-started.md" >}}) to set up Livingdocs locally (in case you haven't you can contact us at contact@livingdocs.io).
+
+
+## Having a first look on edit.livingdocs.io?
+
+You can check out Livingdocs via our service at [edit.livingdocs.io](https://edit.livingdocs.io). This way you do not have to set up anything locally and can see quickly how our editor and our REST Api work. On the service you will be set up with a preconfigured project.
+
+There is a separate documentation to get you started quickly with our service at [developers.livingdocs.io](https://developers.livingdocs.io).
+
+
+## Guides
+
+If you would like to get a specific task done head over to the [guides]({{< ref "guides" >}}) section.
+
+
+## Operations
+
+To see common setups, cloud deployments, required services and monitoring options refer to our [devops section]({{< ref "operations/self-hosting.md" >}}).
+
+
+{{< img src="illustration.png" alt="Livingdocs in a Box" >}}
+
+
+## Feedback
+
+Please let us know about gaps or errors in our documentation at [documentation@livingdocs.io](mailto:documentation@livingdocs.io) or you can do a pull request on https://github.com/livingdocsIO/livingdocs.
+
+(If you are viewing this documentation on our Github repository, there is a new nicer view of it at https://docs.livingdocs.io)

--- a/nginx.conf
+++ b/nginx.conf
@@ -25,7 +25,8 @@ http {
   map_hash_bucket_size 256;
   map $request_uri $new_uri {
     default "";
-    /enterprise /;
+    / /home;
+    /enterprise /home;
     /contribution-guidelines/contributing /;
     /devops/how-to-do-a-load-test /operations/maintenance/how-to-do-a-load-test/;
     /devops/how-to-varnish /operations/maintenance/how-to-varnish/;


### PR DESCRIPTION
## Changelog
🔧 Introdcue /home to deal with permanent redirects from / to /enterprise (we added another non-permanent redirect to /home)