### PR TITLE
chore: More reasonable sample value for maxArea

### DIFF
--- a/content/reference-docs/editor-configuration/image-cropping.md
+++ b/content/reference-docs/editor-configuration/image-cropping.md
@@ -19,7 +19,7 @@ For all configurable options in the library, see [here](https://github.com/livin
       showSurroundingImage: 'always',
       surroundingImageOpacity: 0.5,
       zoomStep: 1.05,
-      maxArea: 0.5
+      maxArea: null
     }
   },
   disableCropFor: ['image/svg+xml']  

--- a/content/reference-docs/editor-configuration/image-cropping.md
+++ b/content/reference-docs/editor-configuration/image-cropping.md
@@ -18,8 +18,7 @@ For all configurable options in the library, see [here](https://github.com/livin
     imageCrop: {
       showSurroundingImage: 'always',
       surroundingImageOpacity: 0.5,
-      zoomStep: 1.05,
-      maxArea: null
+      zoomStep: 1.05
     }
   },
   disableCropFor: ['image/svg+xml']  
@@ -43,13 +42,6 @@ Deduces the opacity with which the cropped out parts are shown (see above).
 Possible values: between 1 and 2, Default: 1.25
 
 Deduces zoom steps when zooming into an image and out. 1.05 zooms in 5% with every step.
-
-### maxArea
-
-Possible values: null or between 0 and 1, Default: null
-
-If set to `null` (or left out in the config) the full image will be shown and changing the horizontal and vertical sizes will keep the other respective size constant.
-If set to a value between 0 and 1 changing the sizes will affect the whole ratio (width and height) and fill the area given in max area (e.g. 0.8 -> 80%).
 
 ### disableCropFor
 


### PR DESCRIPTION
Setting a non-null `maxArea` leads to behavior that is probably not desired in most cases in combination with "free" cropping (without fixed aspect ratio), so I suggest it to `null` in the code sample.

Case in point: T-Online were confused by this behavior 👇


https://user-images.githubusercontent.com/47303530/132364105-d2370395-73ed-4ec5-a67f-dcc9b102d409.mov

