### PR TITLE
fix: Add default values for li-list-reference

### DIFF
--- a/content/guides/documents/includes/list-teasers.md
+++ b/content/guides/documents/includes/list-teasers.md
@@ -19,11 +19,11 @@ This guide assumes that you are familiar with the possibilities to register an I
       type: 'li-list-reference',
       preload: true, // Populate referenced article data
       config: {
-        enableCount: true, // Show the count option within the editor UI
-        defaultCount: 3,
-        minCount: 2,
-        maxCount: 6,
-        enableListEditing: true // Enable list creation and editing within the editor UI
+        enableCount: true,      // enable UI configuration of number of articles (default: false)
+        defaultCount: 3,        // number of articles shown by default (default: 3)
+        minCount: 2,            // minimum number of articles
+        maxCount: 6,            // maximum number of articles
+        enableListEditing: true // allow to create/edit list inline (default: false)
       }
     }
   ],

--- a/content/reference-docs/document/metadata/metadata-plugin-list.md
+++ b/content/reference-docs/document/metadata/metadata-plugin-list.md
@@ -331,11 +331,11 @@ metadata: [{
   ...,
   type: 'li-list-reference',
   config: {
-    enableCount: true,      // enable configuration of number of articles
-    defaultCount: 3,        // number of articles shown by default
+    enableCount: true,      // enable UI configuration of number of articles (default: false)
+    defaultCount: 3,        // number of articles shown by default (default: 3)
     minCount: 2,            // minimum number of articles
-    maxCount,               // maximum number of articles
-    enableListEditing: true // allow to create/edit list inline
+    maxCount: 6,            // maximum number of articles
+    enableListEditing: true // allow to create/edit list inline (default: false)
   }
 }]
 ```


### PR DESCRIPTION
This PR is primarily aimed at documenting the new default list count introduced by https://github.com/livingdocsIO/livingdocs-server/pull/4099. I also liked the comments @romankaravia added, so I copied them to the other `li-list-reference` location and tweaked them slightly.