### PR TITLE
fix(metadata): add hideFromForm example

### DIFF
--- a/content/reference-docs/document/metadata/_index.md
+++ b/content/reference-docs/document/metadata/_index.md
@@ -38,13 +38,20 @@ metadata: [{
   handle: 'title',
   plugin: 'li-text',
   config: {
+    // li-text specific configs
     maxLength: 200,
+
+    // general configs available for all plugins
     required: true,
     requiredErrorMessage: 'please provide a title'
   }
 }, {
   handle: 'slug',
   plugin: 'li-text',
+  config: {
+    // Do not display this field in the Editor
+    hideFromForm: true
+  }
 }, {
   handle: 'seo',
   plugin: 'li-seo'


### PR DESCRIPTION
## Changelog

- Add quick example with `hideFromForm` to the docs. It's not ideal but better that if it is not mentioned anywhere.