### PR TITLE
Refactor of added-in shortcode

### DIFF
--- a/content/operations/releases/master/master.md
+++ b/content/operations/releases/master/master.md
@@ -3,6 +3,8 @@ type: release-notes
 title: March 2022 Release
 description: Release notes for release-2022-03
 excludeFromSearch: true
+aliases:
+  - /operations/releases/release-2022-03/release-2022-03/
 ---
 
 {{< release-header

--- a/content/reference-docs/project-config/media-types.md
+++ b/content/reference-docs/project-config/media-types.md
@@ -271,7 +271,7 @@ Here is a complete list of fields you can use. Please consult https://www.iptc.o
 ## Media Sources
 
 
-{{< added-in release-2021-03 >}}
+{{< added-in release-2021-03 block >}}
 
 This feature is only supported for mediaTypes of type `mediaImage`.
 

--- a/themes/hugo-docs/layouts/partials/added-in.html
+++ b/themes/hugo-docs/layouts/partials/added-in.html
@@ -1,0 +1,6 @@
+{{- $href := "/operations/releases/{{ .release }}/{{ .release }}/" -}}
+{{- if .block -}}
+<p class="added-in">Added in: <a href="{{ $href }}"><code>{{ .release }}</code></a></p>
+{{- else -}}
+<span class="added-in">Added in: <a href="{{ $href }}"><code>{{ .release }}</code></a></span>
+{{- end -}}

--- a/themes/hugo-docs/layouts/shortcodes/added-in.html
+++ b/themes/hugo-docs/layouts/shortcodes/added-in.html
@@ -1,1 +1,3 @@
-<span class="added-in">Added in: <a href="/operations/releases/{{ .Get 0 }}/{{ .Get 0 }}/"><code>{{ .Get 0 }}</code></a></span>{{- "" -}}
+{{- $release := .Get 0 -}}
+{{- $block := .Get 1 -}}
+{{- partial "added-in" (dict "release" $release "block" $block) -}}

--- a/themes/hugo-docs/layouts/shortcodes/api-example.html
+++ b/themes/hugo-docs/layouts/shortcodes/api-example.html
@@ -16,24 +16,24 @@
 {{- $parameters := index $segmentsParameters 0 | markdownify -}}
 {{- $description := index $segmentsDescription 0 | markdownify -}}
 
-<div class="api-example{{ with (eq $title "") }} api-example--no-title{{ end }}{{ if $beta }} api-example--beta{{ end }}">
+<div class="api-example{{ if (eq $title "") }} api-example--no-title{{ end }}{{ if $beta }} api-example--beta{{ end }}">
 
-  {{- with (ne $title "") -}}
+  {{- if (ne $title "") -}}
     <h2 class="api-example__title">{{ $title }}</h2>
   {{- end -}}
 
-  {{- with (ne $description "") -}}
+  {{- if (ne $description "") -}}
     <div class="api-example__description">
       <h4>Description</h4>
       {{- $description -}}
     </div>
   {{- end -}}
 
-  {{- with (ne $query "") -}}
+  {{- if (ne $query "") -}}
     <div class="api-example__curl">
       <div class="teaser-and-code">
         <div class="teaser-and-code__teaser">
-          <div class="code-teaser{{ with (ne $showResponseCode true) }} code-teaser--with-interaction{{ end }}">
+          <div class="code-teaser{{ if (ne $showResponseCode true) }} code-teaser--with-interaction{{ end }}">
             <div class="code-teaser__interaction">
               <span class="arrow"></span>
             </div>
@@ -48,19 +48,19 @@
     </div>
   {{- end -}}
 
-  {{- with (ne $endpoint "") -}}
+  {{- if (ne $endpoint "") -}}
     <h4>Endpoint</h4>
     {{- $endpoint -}}
   {{- end -}}
 
-  {{- with (ne $parameters "") -}}
+  {{- if (ne $parameters "") -}}
     <h4>Parameters</h4>
     {{- $parameters -}}
   {{- end -}}
 
-  {{- with (ne (index $segmentsResponse 0) "") -}}
+  {{- if (ne (index $segmentsResponse 0) "") -}}
     <div class="api-example__response">
-      <h4>Response{{ with (eq $responseBlurry true) }} (may differ in details){{ end }}</h4>
+      <h4>Response{{ if (eq $responseBlurry true) }} (may differ in details){{ end }}</h4>
 
       {{- range $item, $segmentsResponse -}}
         {{- $code := index (split $item "---") 0  | markdownify -}}
@@ -70,22 +70,22 @@
         <div class="api-example__response-entry">
           <div class="teaser-and-code">
             <div class="teaser-and-code__teaser">
-              <div class="code-teaser{{ with (ne $showResponseCode true) }} code-teaser--with-interaction{{ end }}{{ with (eq $code "200") }} code-teaser--success{{ end }}{{ with (ne $code "200") }} code-teaser--error{{ end }}">
+              <div class="code-teaser{{ if (ne $showResponseCode true) }} code-teaser--with-interaction{{ end }}{{ if (eq $code "200") }} code-teaser--success{{ end }}{{ if (ne $code "200") }} code-teaser--error{{ end }}">
                 <div class="code-teaser__interaction">
                   <span class="arrow"></span>
                 </div>
                 
                 <div class="code-teaser__code">{{ $code }}</div>
-                {{- with (eq $code "200") -}}<div class="code-teaser__name">OK</div>{{- end -}}
-                {{- with (eq $code "301") -}}<div class="code-teaser__name">Moved Permanently</div>{{- end -}}
-                {{- with (eq $code "400") -}}<div class="code-teaser__name">Bad Request</div>{{- end -}}
-                {{- with (eq $code "401") -}}<div class="code-teaser__name">Unauthorized</div>{{- end -}}
-                {{- with (eq $code "403") -}}<div class="code-teaser__name">Forbidden</div>{{- end -}}
-                {{- with (eq $code "404") -}}<div class="code-teaser__name">Not Found</div>{{- end -}}
-                {{- with (eq $code "409") -}}<div class="code-teaser__name">Conflict</div>{{- end -}}
-                {{- with (eq $code "429") -}}<div class="code-teaser__name">Usage Limit Exceeded</div>{{- end -}}
-                {{- with (eq $code "500") -}}<div class="code-teaser__name">Bad Request</div>{{- end -}}
-                {{- with (ne $endpoint "") -}}<div class="code-teaser__endpoint">{{ $endpoint }}</div>{{- end -}}
+                {{- if (eq $code "200") -}}<div class="code-teaser__name">OK</div>{{- end -}}
+                {{- if (eq $code "301") -}}<div class="code-teaser__name">Moved Permanently</div>{{- end -}}
+                {{- if (eq $code "400") -}}<div class="code-teaser__name">Bad Request</div>{{- end -}}
+                {{- if (eq $code "401") -}}<div class="code-teaser__name">Unauthorized</div>{{- end -}}
+                {{- if (eq $code "403") -}}<div class="code-teaser__name">Forbidden</div>{{- end -}}
+                {{- if (eq $code "404") -}}<div class="code-teaser__name">Not Found</div>{{- end -}}
+                {{- if (eq $code "409") -}}<div class="code-teaser__name">Conflict</div>{{- end -}}
+                {{- if (eq $code "429") -}}<div class="code-teaser__name">Usage Limit Exceeded</div>{{- end -}}
+                {{- if (eq $code "500") -}}<div class="code-teaser__name">Bad Request</div>{{- end -}}
+                {{- if (ne $endpoint "") -}}<div class="code-teaser__endpoint">{{ $endpoint }}</div>{{- end -}}
               </div>
             </div>
             <div class="teaser-and-code__code{{ if $showResponseCode }} show{{ end }}">

--- a/themes/hugo-docs/layouts/shortcodes/api-example.html
+++ b/themes/hugo-docs/layouts/shortcodes/api-example.html
@@ -1,4 +1,5 @@
 {{- $title := .Get "title" -}}
+{{- $release := .Get "release" -}}
 {{- $beta := .Get "beta" -}}
 {{- $showResponseCode := .Get "showResponseCode" -}}
 {{- $responseBlurry := .Get "responseBlurry" -}}
@@ -20,6 +21,10 @@
 
   {{- if (ne $title "") -}}
     <h2 class="api-example__title">{{ $title }}</h2>
+  {{- end -}}
+
+  {{- if (ne $release "") -}}
+    {{- partial "added-in" (dict "release" $release "block" true) -}}
   {{- end -}}
 
   {{- if (ne $description "") -}}


### PR DESCRIPTION
# Changelog

- Added an alias to the master release page so that added-in can support upcoming releases (e.g. release-2022-03)
- Changed the api-example template to use `if` instead of `while` as it's easier to understand, and the while scope was not used
- Created an `added-in` partial, which the existing shortcode now uses
- Added support for block `added-in` which can be used to add a margin bottom (`p` element instead of `span`)
- Extended the api-example template with added-in partial so that new endpoints can indicate when they were added


# Internal Changes

I couldn't find a way for the `.Get 0` in the "added-in" shortcode to work with custom contexts, which would have allowed me to use the shortcode directly from the "api-example" shortcode. The only way around it that I could find was to use a partial template. For the partial I found it more readable to repeat the element content in an if/else conditional rather than the [`printf`](https://discourse.gohugo.io/t/using-custom-variables-for-html-tags/15034/7) approach I found.