### PR TITLE
fix: Move deliveryLinks out of frontend in contentTypes.editor schema

### DIFF
--- a/content/reference-docs/project-config/content-types.md
+++ b/content/reference-docs/project-config/content-types.md
@@ -82,23 +82,21 @@ contentTypes: [{
       disableEditTitleAtToolbar: false
     },
 
-    frontend: {
-      // One or multiple deliveryLinks are show in the publish panel
-      // They should point to your frontends
-      // url can be a pattern containing these placeholders:
-      // :path
-      // :routingPath
-      // :id
-      // :projectId
-      // :slug
-      deliveryLinks: [
-        {
-          url: 'http://localhost:9999/:slug',
-          icon: 'link-variant',
-          label: 'Publish link'
-        }
-      ]
-    }
+    // One or multiple deliveryLinks are show in the publish panel
+    // They should point to your frontends
+    // url can be a pattern containing these placeholders:
+    // :path
+    // :routingPath
+    // :id
+    // :projectId
+    // :slug
+    deliveryLinks: [
+      {
+        url: 'http://localhost:9999/:slug',
+        icon: 'link-variant',
+        label: 'Publish link'
+      }
+    ]
   },
 
   // if enabled is true this content-type will use the WoodWing


### PR DESCRIPTION
The content type schema can be found here: https://github.com/livingdocsIO/livingdocs-server/blob/bc1086f2482d4fa7124b0b55b0223ebc95ff0733/app/features/channel-configs/config-properties/content-types/content_types_schema.js#L119-L127