### PR TITLE
fix(added-in): Fix URL in shortcode and partial

### DIFF
--- a/content/reference-docs/project-config/settings.md
+++ b/content/reference-docs/project-config/settings.md
@@ -212,14 +212,13 @@ If you activate the translation feature, then the `language` metadata plugin on 
 
 Since integrations typically require a correct connection to be establised we strongly advise to use our UIs under "Project Setup" to set them up.
 
-In general all integrations are under the `integrations` key. We still have some legacy markup where the integration is directly on the root (`desknet` and `netlify`), but we will move those in the future.
+In general all integrations are under the `integrations` key. We still have some legacy markup where the integration is directly on the root (`desknet`), but this will be moved in the future.
 
 Available plugins are:
 - Desk-Net (planning)
 - iMatrics (text auto-tagging)
 - Google Vision (image auto-tagging)
 - Comyan (external image storage)
-- Netlify (static rendering)
 
 ### Imatrics
 

--- a/themes/hugo-docs/layouts/partials/added-in.html
+++ b/themes/hugo-docs/layouts/partials/added-in.html
@@ -1,4 +1,4 @@
-{{- $href := "/operations/releases/{{ .release }}/{{ .release }}/" -}}
+{{- $href := print "/operations/releases/" .release "/" .release "/" -}}
 {{- if .block -}}
 <p class="added-in">Added in: <a href="{{ $href }}"><code>{{ .release }}</code></a></p>
 {{- else -}}


### PR DESCRIPTION
Current URLs are https://docs.livingdocs.io/operations/releases/%7b%7b%20.release%20%7d%7d/%7b%7b%20.release%20%7d%7d/ instead of https://docs.livingdocs.io/operations/releases/release-2022-03/release-2022-03/ because the template variables are not parsed during variable assignment.