### PR TITLE
remove design specific property

### DIFF
--- a/content/guides/documents/includes/list-teasers.md
+++ b/content/guides/documents/includes/list-teasers.md
@@ -114,7 +114,6 @@ This guide assumes that you are familiar with the possibilities to register an I
     label: 'show byline',
     default: true
   }],
-  properties: ['teaser-type'],
   html: `
     <a class="teaser" doc-link="link">
       <img class="responsive-img" doc-image="image">


### PR DESCRIPTION
The properties are defined in the `design_settings` and we shouldn't assume in the documentation that customers use a specific design.