### PR TITLE
fix: custom spellcheck service url

### DIFF
--- a/content/reference-docs/editor-extensions/editor-configuration/text-editing.md
+++ b/content/reference-docs/editor-extensions/editor-configuration/text-editing.md
@@ -304,7 +304,7 @@ app: {
 },
 spellcheck: {
   isEnabled: true,
-  'host': 'http://your-spellcheck-server.com/spellcheck'
+  'host': 'http://your-spellcheck-server.com'
 }
 ```
 
@@ -314,7 +314,7 @@ individual paragraphs.
 
 Example request:
 ```http
-GET http://your-spellcheck-server.com/spellcheck?text=foobar
+GET http://your-spellcheck-server.com/spellcheck/check?text=foobar
 ```
 
 Spellcheck response with no corrections:


### PR DESCRIPTION
Seems that `spellcheck/check` path along with the `?text=<value>` query are added to the configured host.