### PR TITLE
feat(retresco): Document live analysis option

### DIFF
--- a/content/guides/integrations/retresco.md
+++ b/content/guides/integrations/retresco.md
@@ -4,6 +4,8 @@ description: Analyze documents and store entities in a metadata field with the R
 weight: 8
 ---
 
+{{< added-in release-2022-03 block >}}
+
 The [Retresco](https://www.retresco.com/) integration uses semantic analysis and keywording to tag documents with relevant entities. These entities are then stored within a document's metadata and can be used to categorise documents.
 
 ## Configuration
@@ -28,7 +30,11 @@ Enable the integration on the server level by setting `allowed: true`. You can a
 
 ### Project
 
-Each project also needs to be configured to use the Retresco integration. You need to specify the Retresco API credentials, and optionally provide the text extraction "matches". `titleMatches`, `supertitleMatches`, and `teaserMatches` are arrays of `<component-name>.<directive-name>` strings which can be used to extract the text content and deliver them to the Retresco API in the relevant fields within the request payload. Only the first match found for each field will be used, but multiple values can be provided so that many content types can be supported.
+Each project also needs to be configured to use the Retresco integration. You must set `enabled: true` to activate the feature, and provide the Retresco API endpoint and credentials.
+
+You can also optionally provide the text extraction "matches". `titleMatches`, `supertitleMatches`, and `teaserMatches` are arrays of `<component-name>.<directive-name>` strings which can be used to extract the text content and deliver them to the Retresco API in the relevant fields within the request payload. Only the first match found for each field will be used, but multiple values can be provided so that many content types can be supported.
+
+The default behaviour is to analyse the text on the idle event, typically 5 seconds after a user stops typing, so that the tags are always up-to-date with the content. If you would like to prevent text analysis while a user is working on a document it is possible to set `enableLiveAnalysis: false`. Once disabled the only way the tags will be updated is by the user clicking the refresh button in the metadata form, or at the time of publication.
 
 ```js
 {
@@ -46,6 +52,7 @@ Each project also needs to be configured to use the Retresco integration. You ne
             name: '<secret-name>' // See Project Secret section below
           }
         },
+        enableLiveAnalysis: true,
         titleMatches: ['header.title'],
         supertitleMatches: ['header.catchline'],
         teaserMatches: ['p.text']

--- a/content/reference-docs/project-config/settings.md
+++ b/content/reference-docs/project-config/settings.md
@@ -58,6 +58,7 @@ settings: {
           name: '<secret-name>'
         }
       },
+      enableLiveAnalysis: true,
       // The component.directive combinations used to extract specific strings.
       // The first match will be used, but multiple values can be provided so that many
       // content types can be supported.


### PR DESCRIPTION
Relations:
  - Related PR's:
    - https://github.com/livingdocsIO/livingdocs-server/pull/4415
    - https://github.com/livingdocsIO/livingdocs-editor/pull/5205

This PR adds an explanation about the `enableLiveAnalysis` boolean option added to the project config.