### PR TITLE
Update documentPropertyNameConfigs

### DIFF
--- a/content/reference-docs/editor-extensions/editor-configuration/display-filter.md
+++ b/content/reference-docs/editor-extensions/editor-configuration/display-filter.md
@@ -11,8 +11,8 @@ Possible values for `displayFilters` are:
   displayFilters: ['liDateTimeRange']
 
   // custom config
-  //   documentPropertyName 'createdAt'/'updatedAt'
-  //   metadataPropertyName -> filter by any of your metadata date fields
+  //   documentPropertyName: Supports 'createdAt'/'updatedAt', defaults to updatedAt
+  //   metadataPropertyName: Supports any of your metadata date fields
   displayFilters: [{filterName: 'liDateTimeRange', config: {documentPropertyName: 'createdAt'}}]
   displayFilters: [{filterName: 'liDateTimeRange', config: {metadataPropertyName: 'publicationDate'}}]
   ```


### PR DESCRIPTION
I have updated the config for the liDateTimeRange filter, so wanted to make the documentation slightly clearer. 

Now it states we support updated at and created at, but also explains the default is updated at. 