### PR TITLE
fix(mult text select): optional

### DIFF
--- a/content/reference-docs/editor-extensions/editor-configuration/editing-features.md
+++ b/content/reference-docs/editor-extensions/editor-configuration/editing-features.md
@@ -200,21 +200,17 @@ See [here]({{< ref "./text-editing.md#links" >}})
 The keyboard shortcuts allow you to customize which keys you want to use for common actions in Livingdocs.
 The actions (values) are fixed. You can define on which keys you want to execute the actions
 
-## Multi select
+## Multi Select and Multi Text Select
 
-Selecting multiple components at once allows editors to delete a bulk of components.
-The multi selection is currently only enabled through keyboard shortcuts (see above). To enable it, add this to the shortcut definition:
+Selecting multiple components at once allows editors to delete a bulk of components. Editors can select multiple components by dragging from outside of the component view.
+
+The selection of text across multiple components by dragging inside of a text component is enabled by default but can be disabled in the editable settings:
+
 ```js
-{
-  keyboardShortcuts: {
-    '↓shift': 'start multiselect mode',
-    '↑shift': 'end multiselect mode',
-  }
+editable: {
+  multiEditablesTextSelection: false,
 }
 ```
-
-This will allow editors to use Shift+Click to multi-select components. Of course you can also choose to have different shortcuts.
-
 
 ## Document Copy
 


### PR DESCRIPTION
Whilst fixing ongoing bugs with the text multi selection I added the ability to disable text-multi selection with [this PR](https://github.com/livingdocsIO/livingdocs-editor/pull/5416)

I added this to the docs and in the meantime updated the fact that multi-component select no longer requires the shift key shortcut.