### PR TITLE
textcount: add textcount.showEditableCount doc

### DIFF
--- a/content/reference-docs/editor-extensions/editor-configuration/text-editing.md
+++ b/content/reference-docs/editor-extensions/editor-configuration/text-editing.md
@@ -336,6 +336,7 @@ count text within certain components.
 ```js
 textcount: {
   isEnabled: true,
+  showEditableCount: true // shows the chars of the selected doc-editable
   timeout: 200
 }
 ```


### PR DESCRIPTION
This was added a while back, here is the doc: https://github.com/livingdocsIO/livingdocs-editor/pull/4617