### PR TITLE
fix: Add new oEmbed providers to reference-docs

### DIFF
--- a/content/reference-docs/server-extensions/include-functions/_index.md
+++ b/content/reference-docs/server-extensions/include-functions/_index.md
@@ -22,6 +22,11 @@ Core oEmbed providers:
 - Twitter (`li-twitter`)
 - Vimeo (`li-vimeo`)
 - YouTube (`li-youtube`)
+- Podigee (`li-podigee`) {{< added-in release-2022-07 >}}
+- Datawrapper (`li-datawrapper`) {{< added-in release-2022-07 >}}
+- Spotify (`li-spotify`) {{< added-in release-2022-07 >}}
+- Instagram (`li-instagram`), ATTENTION: requires credentials {{< added-in release-2022-07 >}}
+- Facebook (`li-facebook-post`), ATTENTION: requires credentials {{< added-in release-2022-07 >}}
 
 For details on how to setup and configure an oEmbed include please read the [guide]({{< ref "/guides/documents/includes/oembed" >}}).
 


### PR DESCRIPTION
Updating the list of oEmbed providers in the include function page within reference-docs based on the list in the guide.