### PR TITLE
fix: Remove extra builds from PRs to Categorize

### DIFF
--- a/content/operations/releases/master/master.md
+++ b/content/operations/releases/master/master.md
@@ -29,8 +29,6 @@ These are the release notes of the upcoming release (pull requests merged to mas
 ## PRs to Categorize
 * :new: fix(desknet): Don't use scheduleEnabled project config property [livingdocs-editor #5589 v80.39.22](https://github.com/livingdocsIO/livingdocs-editor/pull/5589)
 * :new: Fix: Ensure UI updates when images/videos are edited in Embedded Documents [livingdocs-editor #5608 v80.39.21](https://github.com/livingdocsIO/livingdocs-editor/pull/5608)
-* :new: Fix: Ensure UI updates when images/videos are edited in Embedded Documents [livingdocs-editor #5608 v80.39.22](https://github.com/livingdocsIO/livingdocs-editor/pull/5608)
-* :new: Dashboards: Show correct contentType selection on create from custom dashboards [livingdocs-editor #5602 v80.39.21](https://github.com/livingdocsIO/livingdocs-editor/pull/5602)
 * :new: Dashboards: Show correct contentType selection on create from custom dashboards [livingdocs-editor #5602 v80.39.21](https://github.com/livingdocsIO/livingdocs-editor/pull/5602)
 * :new: Test/Flatter Design [livingdocs-editor #5605 v80.39.20](https://github.com/livingdocsIO/livingdocs-editor/pull/5605)
 * :new: Fix: Dashboard Create Button available when contentType filters defined, also for custom dashboards [livingdocs-editor #5598 v80.39.19](https://github.com/livingdocsIO/livingdocs-editor/pull/5598)


### PR DESCRIPTION
The two following commits ended up in release v80.39.21 due to build failures:
- Fix: Ensure UI updates when images/videos are edited in Embedded Documents
- Dashboards: Show correct contentType selection on create from custom dashboards