### PR TITLE
Add Desk-Net Schedule Extensions + Production Features

### DIFF
--- a/content/guides/integrations/desknet/index.md
+++ b/content/guides/integrations/desknet/index.md
@@ -1,5 +1,5 @@
 ---
-title: Desk-Net integration
+title: Desk-Net Integration
 description: Integrate Desk-Net with Livingdocs
 weight: 1
 ---
@@ -68,9 +68,6 @@ Add the following to the project config of the project you want to connect with 
   desknet: {
     enabled: true,
 
-    // See "Story Planning Schedule in Livingdocs" section below
-    scheduleEnabled: true,
-
     credentials: {
       clientId: '******',
       clientSecret: {
@@ -121,80 +118,98 @@ Add the following to the project config of the project you want to connect with 
 
 #### 5. Add metadata plugin to content types
 
-Add the following metadata plugin to all content types that can be created using the "contentTypes" configuration above:
+Add the `li-desknet-integration` metadata plugin to all content types that can be created using the "contentTypes" configuration in the previous step:
 
 ```js
 {
-  handle: 'desknet',
-  type: 'li-desknet-integration',
+  handle: 'article',
+  documentType: 'article',
+  // ...
+  metadata: [
+    // ...
+    {
+      handle: 'desknet',
+      type: 'li-desknet-integration',
 
-  // {{< added-in release-2022-07 >}}
-  // The config can be used if you intend to keep Desk-Net's publication status up-to-date
-  // with the status of the document in Livingdocs. It is required if you intend to publish a
-  // document in Livingdocs when updating the publication status in Desk-Net.
-  config: {
-    publicationStatus: {
-      // Optional. The fallback is used when no matcher condition is met for a document.
-      fallbackPublicationStatusId: 3,
+      // {{< added-in release-2022-07 >}}
+      // The config can be used if you intend to keep Desk-Net's publication status up-to-date
+      // with the status of the document in Livingdocs. It is required if you intend to publish a
+      // document in Livingdocs when updating the publication status in Desk-Net.
+      config: {
+        publicationStatus: {
+          // Optional. The fallback is used when no matcher condition is met for a document.
+          fallbackPublicationStatusId: 3,
 
-      // Matchers provide a way to synchronise the state of a Livingdocs document to Desk-Net.
-      // You can use publication, task, or metadata matchers to calculate a Desk-Net
-      // publication status id value. You can find the publicationStatusId value using the
-      // Desk-Net API, or by inspecting network requests in the Statuses page in Desk-Net.
-      // The order of matchers is important. The array is iterated through from first to last,
-      // with the publicationStatusId taken from the earliest document state match.
-      matchers: [
-        {
-          // Defining a publicationStatusId for the published status is required if you intend to
-          // publish a document in Livingdocs when updating the publication status in Desk-Net.
-          type: 'publication',
-          value: 'published',
-          publicationStatusId: 5
-        },
-        {
-          type: 'task',
-          taskName: 'proofreading',
-          value: 'completed', // The "value" of a task can be requested, accepted, or completed
-          publicationStatusId: 25912
-        },
-        {
-          type: 'metadata',
-          propertyName: 'my-custom-plugin.status', // uses lodash.get()
-          value: 'in-progress', // compares with lodash.isEqual()
-          publicationStatusId: 123
+          // Matchers provide a way to synchronise the state of a Livingdocs document to Desk-Net.
+          // You can use publication, task, or metadata matchers to calculate a Desk-Net
+          // publication status id value. You can find the publicationStatusId value using the
+          // Desk-Net API, or by inspecting network requests in the Statuses page in Desk-Net.
+          // The order of matchers is important. The array is iterated through from first to last,
+          // with the publicationStatusId taken from the earliest document state match.
+          matchers: [
+            {
+              // Defining a publicationStatusId for the published status is required if you intend to
+              // publish a document in Livingdocs when updating the publication status in Desk-Net.
+              type: 'publication',
+              value: 'published',
+              publicationStatusId: 5
+            },
+            {
+              type: 'task',
+              taskName: 'proofreading',
+              value: 'completed', // The "value" of a task can be requested, accepted, or completed
+              publicationStatusId: 25912
+            },
+            {
+              type: 'metadata',
+              propertyName: 'my-custom-plugin.status', // uses lodash.get()
+              value: 'in-progress', // compares with lodash.isEqual()
+              publicationStatusId: 123
+            }
+          ]
         }
-      ]
-    }
-  },
+      },
 
-  // {{< added-in release-2022-07 >}}
-  // Only required if you intend to display the current publication status in a table dashboard cell
-  ui: {
-    config: {
-      publicationStatus: {
-        labels: [
-          {
-            publicationStatusId: 5,
-            label: 'Published',
-            // SVG icons can be minimised and optimised using https://jakearchibald.github.io/svgomg/
-            // The SVG icon should have a viewBox property to scale properly.
-            icon: '<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 15 17"><path class="colour" d="M.333 1.447v14.334h14.334V1.447H.333zM13.11 14.224H1.891V3.004h11.22v11.22z"/><circle class="colour" cx="7.5" cy="8.749" r="2.042"/></svg>',
-            color: '#778397'
-          },
-          {
-            publicationStatusId: 25912,
-            label: 'Proofreading Completed',
-            icon: '<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 15 17"><path class="colour" d="M.042 15.778.05 1.445l4.091.003-.008 14.333zM9.537 15.781h-4.09l.008-14.334h4.09l-.008 14.334zM14.992 15.781H10.9l.009-14.334H15l-.008 14.334z"/></svg>',
-            color: '#b56eef'
-          },
-          {
-            publicationStatusId: 123,
-            label: 'In Progress',
-            icon: '<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 15 17"><path class="colour" d="M0 1.25v14.5h14.5V1.25H0zm5.901 12.208L1.767 9.05l1.208-1.13 2.921 3.116L12.3 4.158l1.211 1.129-7.61 8.171z"/></svg>',
-            color: '#82e580'
+      // {{< added-in release-2022-07 >}}
+      // Only required if you intend to display the current publication status in a table dashboard cell
+      ui: {
+        config: {
+          publicationStatus: {
+            labels: [
+              {
+                publicationStatusId: 5,
+                label: 'Published',
+                // SVG icons can be minimised and optimised using https://jakearchibald.github.io/svgomg/
+                // The SVG icon should have a viewBox property to scale properly.
+                icon: '<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 15 17"><path class="colour" d="M.333 1.447v14.334h14.334V1.447H.333zM13.11 14.224H1.891V3.004h11.22v11.22z"/><circle class="colour" cx="7.5" cy="8.749" r="2.042"/></svg>',
+                color: '#778397'
+              },
+              {
+                publicationStatusId: 25912,
+                label: 'Proofreading Completed',
+                icon: '<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 15 17"><path class="colour" d="M.042 15.778.05 1.445l4.091.003-.008 14.333zM9.537 15.781h-4.09l.008-14.334h4.09l-.008 14.334zM14.992 15.781H10.9l.009-14.334H15l-.008 14.334z"/></svg>',
+                color: '#b56eef'
+              },
+              {
+                publicationStatusId: 123,
+                label: 'In Progress',
+                icon: '<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" viewBox="0 0 15 17"><path class="colour" d="M0 1.25v14.5h14.5V1.25H0zm5.901 12.208L1.767 9.05l1.208-1.13 2.921 3.116L12.3 4.158l1.211 1.129-7.61 8.171z"/></svg>',
+                color: '#82e580'
+              }
+            ]
           }
-        ]
+        }
       }
+    }
+  ],
+
+  // Optional
+  desknet: {
+    title: {
+      // Defines if the document title should be synced on document update from
+      // either way, livingdocs -> desknet or desknet -> livingdocs.
+      // By default it is synced.
+      sync: false
     }
   }
 }
@@ -550,27 +565,15 @@ This function resolves to a Desk-Net element [with prefetched values](#what-are-
 
 ## Story Planning Schedule in Livingdocs
 
-{{< added-in release-2022-05 block >}}
+{{< added-in release-2022-09 block >}}
 
 An optional step is to enable the story planning side panel within the Livingdocs editor. This can be configured to only display for certain content types, for example pages to help with page management. This step can also be done without mapping Desk-Net values, but this will result in the side panel displaying document titles instead of document reference cards.
 
 ### Setup
 
-#### Project config
-
-Extend the `desknet` object in your project config with the following:
-
-```js
-{
-  desknet: {
-    scheduleEnabled: true,
-  }
-}
-```
-
 #### Content type config
 
-Add the `li-desknet-platforms` metadata plugin to the content type that you would like the side panel enabled for:
+Add the `li-desknet-schedule` metadata plugin to the content type that you would like the side panel enabled for:
 
 ```js
 {
@@ -578,27 +581,34 @@ Add the `li-desknet-platforms` metadata plugin to the content type that you woul
   documentType: 'page',
   // ...
   metadata: [
+    // ...
     {
-      handle: 'desknet-platforms',
-      type: 'li-desknet-platforms',
+      handle: 'desknet-schedule',
+      type: 'li-desknet-schedule',
+      config: {
+        // Optionally filter the documents which are displayed in the side panel
+        filters: {
+          linkedDocumentsOnly: true,
+          elementStatusIds: [1, 2, 10322, 10332],
+          publicationStatusIds: [5]
+        }),
+        // Only required if li-desknet-integration is not used.
+        // It will compare the metadata value from the path provided
+        // with the externalElement.id property in the Desk-Net element.
+        desknetExternalElementIdMetadataPath: 'myExternalSystem.id',
+        // Enable a button in the side panel which triggers a create flow
+        automaticPlacementCreationFlowHandle: 'myDesknetGenerateContentFlow'
+      },
       ui: {
-        label: 'Desk-Net Platforms',
+        label: 'Desk-Net Schedule',
         config: {
-          placeholder: 'Select a Desk-Net platform or category'
+          placeholder: 'Select a Desk-Net platform or category',
+          // Use a custom table dashboard for the side panel
+          useDashboard: 'articlesSimple'
         }
       }
     }
-  ],
-
-  // Optional
-  desknet: {
-    title: {
-      // Defines if the document title should be synced on document update from
-      // either way, livingdocs -> desknet or desknet -> livingdocs.
-      // By default it is synced.
-      sync: false
-    }
-  }
+  ]
 }
 ```
 
@@ -610,6 +620,135 @@ Once you have made the config changes above you should be able to see a disabled
 
 ### Using the side panel
 
-At the moment the side panel is for information only. A user can change the date to see the scheduled articles in the configured platforms or categories. However, the ability to create teasers by dragging articles from the side panel will be added soon.
+A user can change the date to see the scheduled articles in the configured platforms or categories. If the Desk-Net story is linked to a document in Livingdocs then it is possible to drag the story on to the page to create a teaser.
 
 {{< img src="desknet-schedule-side-panel.png" alt="Desk-Net Schedule side panel in Livingdocs" >}}
+
+### Automatic Teaser Placement
+
+Along with manually dragging stories from the side bar on to the page to create teasers, it is also possible to register a document create flow to update or re-generate the content for the current document.
+
+This feature should be considered beta. It is likely that we will refactor this in the future because the `registerCreateFunction` and `create` naming is not ideal for this scenario, where we are actually updating or generating content.
+
+#### Register Create Function
+
+To begin with you should register a new create function in your server runtime config. Below is an example function which demonstrates the possibility of merging existing document content with new content which is generated from the Desk-Net Schedule:
+
+```js
+liServer.registerInitializedHook(async () => {
+  const documentApi = liServer.features.api('li-documents').document
+  documentApi.registerCreateFunction({
+    handle: 'generateTeasersFromDesknetSchedule',
+    async create ({projectConfig, userId, params = {}, context = {}}) {
+      // Extract Desk-Net elements from schedule tree
+      function extractElements (accumulator, node) {
+        const elements = node.elements || []
+        const nestedElements = node.categories?.reduce(extractElements, []) || []
+        return [
+          ...accumulator,
+          ...elements,
+          ...nestedElements
+        ]
+      }
+      const document = context.document
+      // Keep the first title (if it exists)
+      const title = document.content.find((c) => c.identifier === `${document.design.name}.title`)
+      // Generate a paragraph for each Desk-Net element
+      const elements = (params.schedule || []).reduce(extractElements, [])
+      const elementComponents = elements.map((element, index) => ({
+        content: {text: `${index + 1}. ${element.title}`},
+        identifier: `${document.design.name}.p`
+      }))
+
+      return {
+        content: [
+          title,
+          ...elementComponents
+        ].filter(Boolean)
+      }
+    }
+  })
+})
+```
+
+The main differences between this "generate content" function and a standard create function is that we provide the current `document` in the `context` object so that it is possible to re-use existing components. In addition to this, the return value should be an object that only contains a `content` property which is a [component tree]({{< ref "/reference-docs/document/content/component-tree" >}}) (an array of component objects).
+
+The Desk-Net Schedule loaded in the editor is passed to the function as `params.schedule`, and it has the following tree structure:
+
+```js
+[
+  {
+    id: 1,
+    label: 'Platform 1',
+    breadcrumbs: ['Platform 1'],
+    categories: [
+      {
+        id: 2,
+        label: 'Category 1',
+        breadcrumbs: ['Platform 1', 'Category 1'],
+        categories: [
+          {
+            id: 3,
+            label: 'Subcategory 1',
+            breadcrumbs: ['Platform 1', 'Category 1', 'Subcategory 1'],
+            elements: [
+              {
+                // Full Desk-Net element
+                id: 4,
+                title: 'Article 1',
+                publication: {},
+                // ...
+                // Additional linked document (if available)
+                document: {}
+              }
+            ]
+          }
+        ],
+        elements: [{id: 5, title: 'Article 2', publication: {...}}]
+      },
+      {id: 6, label: 'Category 3', breadcrumbs: [...], categories: [...], elements: [...]}
+    ],
+    elements: [{id: 7, title: 'Article 2', publication: {...}}]
+  },
+  {id: 8, label: 'Platform 2', breadcrumbs: [...], categories: [...], elements: [...]}
+]
+```
+
+The `elements` array will contain [full Desk-Net elements](#full-desk-net-element-example) with an additional `document` property if a link between the Desk-Net element and a Livingdocs document can be found.
+
+#### Update Project Config
+
+The next step is to link the create function to a document creation flow. You can do this by modifying `editorSettings` in your project config:
+
+```js
+{
+  // ...
+  editorSettings: {
+    // ...
+    documentCreationFlows: [
+      // ...
+      {
+        handle: 'myDesknetGenerateContentFlow',
+        createFunction: 'generateTeasersFromDesknetSchedule',
+        createButtonLabel: 'Generate Teasers' // Default: "Run Automatic Placement"
+      }
+    ]
+  }
+}
+```
+
+#### Update Metadata Plugin
+
+Finally, you need to update the `li-desknet-schedule` metadata plugin with the `automaticPlacementCreationFlowHandle`. Once this is setup then a button will be added to the Desk-Net Schedule side panel to trigger the document update.
+
+```js
+{
+  handle: 'desknetSchedule',
+  type: 'li-desknet-schedule',
+  config: {
+    automaticPlacementCreationFlowHandle: 'myDesknetGenerateContentFlow'
+    // ...
+  }
+  // ...
+}
+```

--- a/content/operations/releases/release-2022-09.md
+++ b/content/operations/releases/release-2022-09.md
@@ -163,18 +163,28 @@ References:
 
 ### Desk-Net: Schedule Extensions + Production Features
 
-TODO@Alex: add a nice description + do you have planned to write a documentation?
+The Desk-Net integration has been extended with some new features:
+* Fixing the Desk-Net Schedule side panel to a specific date
+* Filtering the documents displayed in the Desk-Net Schedule side panel by story status, platform status, and whether they have been imported to Livingdocs
+* Linking Livingdocs documents to Desk-Net using a metadata value when li-desknet-integration is not used
+* Registering a server function to handle the placement of teasers into a document using the Desk-Net Schedule data
 
 References:
-* [Documentation?](?)
-* [PR: li-desknet-schedule metadata plugin](https://github.com/livingdocsIO/livingdocs-server/pull/4673)
-* [PR: Add li-desknet-schedule metadata plugin](https://github.com/livingdocsIO/livingdocs-editor/pull/5627)
-* [PR: Schedule filtering](https://github.com/livingdocsIO/livingdocs-server/pull/4678)
-* [PR: Link Desk-Net elements using external ids](https://github.com/livingdocsIO/livingdocs-server/pull/4680)
-* [PR: Limit schedule to a specific date using metadata](https://github.com/livingdocsIO/livingdocs-editor/pull/5664)
-* [PR: Display "Run Automatic Placement" button in Desk-Net Schedule side panel](https://github.com/livingdocsIO/livingdocs-editor/pull/5728)
-* [PR: Desk-Net Schedule: Use a Table Dashboard to show Articles](https://github.com/livingdocsIO/livingdocs-editor/pull/5736)
-* [PR: Desk-Net Schedule side panel improvements](https://github.com/livingdocsIO/livingdocs-editor/pull/5751)
+* Documentation:
+  * [Desk-Net Integration Guide]({{< ref "/guides/integrations/desknet" >}})
+* li-desknet-schedule Metadata Plugin:
+  * [Server PR: li-desknet-schedule metadata plugin](https://github.com/livingdocsIO/livingdocs-server/pull/4673)
+  * [Editor PR: li-desknet-schedule metadata plugin](https://github.com/livingdocsIO/livingdocs-editor/pull/5627)
+  * [Server PR: Schedule filtering](https://github.com/livingdocsIO/livingdocs-server/pull/4678)
+  * [Server PR: Link Desk-Net elements using external ids](https://github.com/livingdocsIO/livingdocs-server/pull/4680)
+  * [Server PR: Limit schedule to a specific date](https://github.com/livingdocsIO/livingdocs-server/pull/4706)
+  * [Editor PR: Limit schedule to a specific date](https://github.com/livingdocsIO/livingdocs-editor/pull/5664)
+* Automatic Placement:
+  * [Server PR: Update document using Desk-Net Schedule](https://github.com/livingdocsIO/livingdocs-server/pull/4766)
+  * [Editor PR: Display "Run Automatic Placement" button in Desk-Net Schedule side panel](https://github.com/livingdocsIO/livingdocs-editor/pull/5728)
+* UI Improvements:
+  * [Editor PR: Desk-Net Schedule: Use a Table Dashboard to show Articles](https://github.com/livingdocsIO/livingdocs-editor/pull/5736)
+  * [Editor PR: Desk-Net Schedule side panel improvements](https://github.com/livingdocsIO/livingdocs-editor/pull/5751)
 
 ### Split Revision/Systemmetadata
 
@@ -284,9 +294,13 @@ This has the effect that required metadata are always present in the `preparePub
 
 * [PR](https://github.com/livingdocsIO/livingdocs-server/pull/4778)
 
+### Metadata Plugin li-desknet-platforms
+
+The `li-desknet-platforms` metadata plugin has been replaced by `li-desknet-schedule`. The `li-desknet-platforms` plugin stored an array of objects containing `platformId` and `categoryId` values. The new `li-desknet-schedule` storage schema is an object with a `platforms` property which stores this array, along with a new `date` property. The new plugin also has some additional config options.
+
 ### Desk-Net scheduleEnabled
 
-Please remove `projectConfig.settings.desknet.scheduleEnabled`, because it has no longer has any effect. The schedule will be enabled when Desk-Net is enabled in the server config, and the content type has the li-desknet-platforms metadata plugin.
+Please remove `projectConfig.settings.desknet.scheduleEnabled`, because it has no longer has any effect. The schedule will be enabled when Desk-Net is enabled in the server config, and the content type has the li-desknet-schedule metadata plugin.
 
 * [PR](https://github.com/livingdocsIO/livingdocs-server/pull/4647)
 

--- a/content/reference-docs/document/metadata/metadata-plugin-list.md
+++ b/content/reference-docs/document/metadata/metadata-plugin-list.md
@@ -22,7 +22,8 @@ You can [create your own plugins]({{< ref "/guides/documents/metadata/metadata-e
 | [Date/Time validity](#li-datetime-validity)        | li-datetime-validity     | Date                                          | M                                                                                  | 2 date/time inputs                                         |
 | [Date/Time](#li-datetime)                          | li-datetime              | Date                                          | D, M                                                                               | date/time input                                            |
 | [Dependencies](#li-dependencies)                   | li-dependencies          | Livingdocs framework dependencies definition  | D                                                                                  | no UI                                                      |
-| [Desk-Net](#li-desknet-integration)                | li-desknet-integration   | Desk-Net Integration                          | D                                                                                  | Link to Desk-Net distribution entry                        |
+| [Desk-Net Integration](#li-desknet-integration)                | li-desknet-integration   | Desk-Net Integration                          | D, T                                                                                  | Link to Desk-Net distribution entry                        |
+| [Desk-Net Schedule](#li-desknet-schedule)                | li-desknet-schedule   | Desk-Net Schedule                          | D                                                                                  | Platform/category select and date input                        |
 | [Document Reference](#li-document-reference)       | li-document-reference    | A reference to another document               | D, M, T                                                                            | document selection (dialog)                                |
 | [Enum](#li-enum)                                   | li-enum                  | string from static list, validated on publish | D, M, T                                                                            | select                                                     |
 | [External Id](#li-external-id)                     | li-external-id           | id marker for an external system              | D, M, T                                                                            | select                                                     |
@@ -214,6 +215,9 @@ metadata: [
 **Default UI**: no UI
 
 ## li-desknet-integration
+
+This plugin is used to connect Desk-Net stories with Livingdocs documents. There are numerous options available to synchronise data between the two platforms. Further details can be found in the [Desk-Net Integration Guide]({{< ref "/guides/integrations/desknet" >}}).
+
 **Storage Format**:
 ```js
 {
@@ -224,7 +228,11 @@ metadata: [
   publicationStatusId: <Integer> // {{< added-in release-2022-07 >}}
 }
 ```
-**Default UI**: Link to Desk-Net distribution entry
+
+**Default UI**:
+
+Document Metadata: Read-only link to Desk-Net distribution entry\
+Table Dashboard: Read-only Desk-Net publication/platform status
 
 **Project Config**
 ```js
@@ -275,6 +283,53 @@ metadata: [
             }
           ]
         }
+      }
+    }
+  }
+]
+```
+
+## li-desknet-schedule
+
+{{< added-in release-2022-09 block >}}
+
+This plugin will allow a user to select Desk-Net platforms and categories that they would like to view in the Desk-Net Schedule side panel. Once selected the Desk-Net button in the editor becomes active and the side panel can be opened. It is possible to lock the schedule to a specific date, as well as filter the Desk-Net stories that are displayed. Further details can be found in the [Desk-Net Integration Guide]({{< ref "/guides/integrations/desknet#story-planning-schedule-in-livingdocs" >}}).
+
+**Storage Format**:
+```js
+{
+  platforms: [
+    {
+      platformId: <Integer>,
+      categoryId: <Integer>
+    }
+  ],
+  date: <ISO8601 String>
+}
+```
+**Default UI**:
+Platform/category select and date input
+
+**Project Config**
+```js
+metadata: [
+  {
+    handle: 'desknetSchedule',
+    type: 'li-desknet-schedule',
+    config: {
+      filters: {
+        linkedDocumentsOnly: true,
+        elementStatusIds: [1, 2, 10322, 10332],
+        publicationStatusIds: [5]
+      }),
+      desknetExternalElementIdMetadataPath: 'myExternalSystem.id',
+      automaticPlacementCreationFlowHandle: 'myDesknetGenerateContentFlow'
+    },
+    ui: {
+      label: 'Desk-Net Schedule',
+      config: {
+        placeholder: 'Select a Desk-Net platform or category',
+        useDashboard: 'articlesSimple'
       }
     }
   }

--- a/content/reference-docs/project-config/content-types.md
+++ b/content/reference-docs/project-config/content-types.md
@@ -141,19 +141,40 @@ contentTypes: [
       contentTypes: ['regular', 'another-handle']
     },
 
+    // Delivery build button and status to be shown in the Publish Control panel
+    deliveries: [
+      { deliveryName: 'web', isPrimary: true }
+    ],
+
+    // See the "Desk-Net Integration" guide for further details
     desknet: {
       title: {
         // Defines if the document title should be synced on document update from
         // either way, livingdocs -> desknet or desknet -> livingdocs.
         // By default it is synced.
         sync: false
-      }
-    },
-
-    // Delivery build button and status to be shown in the Publish Control panel
-    deliveries: [
-      { deliveryName: 'web', isPrimary: true }
-    ]
+      },
+      // Link and optionally synchronise Desk-Net element values with Livingdocs metadata
+      metadata: [
+        {
+          sync: false,
+          source: 'slug',
+          target: 'metadata.desknetWorkingTitle'
+        }, {
+          sync: true,
+          source: 'publication.scope',
+          target: 'metadata.targetLength.characters'
+        }
+      ],
+      // A more customisable way to link Desk-Net element values with Livingdocs metadata
+      metadataTransforms: [
+        {
+          importFunctionHandle: 'getPrintPublicationDate',
+          exportFunctionHandle: null,
+          target: 'metadata.desknetPublicationDate'
+        }
+      ]
+    }
   }
 ]
 ```

--- a/content/reference-docs/project-config/settings.md
+++ b/content/reference-docs/project-config/settings.md
@@ -104,6 +104,36 @@ settings: {
     }
   },
 
+  // See the "Desk-Net Integration" guide for further details
+  desknet: {
+    enabled: true,
+    credentials: {
+      clientId: 'my-desknet-client-id',
+      clientSecret: {
+        $secretRef: {
+          name: 'my-desknet-secret-ref'
+        }
+      }
+    },
+    titlePath: 'slug', // Default: "title"
+    publicationStatus: {
+      sync: false,
+      publishedStatus: 5, // Deprecated
+      unpublishedStatus: 1 // Deprecated
+    },
+    contentTypes: {
+      standard: 'regular', // Required. The default content type to create.
+      // Configuration of additional content types that can be created
+      source: 'publication.type.name',
+      mapping: [
+        {
+          source: 'article', // publication.type.name value
+          target: 'regular' // Livingdocs content type handle
+        }
+      ]
+    }
+  },
+
   includeServices: [
     {
       handle: 'echo-service',


### PR DESCRIPTION
- Added Automatic Placement configuration to the Desk-Net Integration guide
- Changed setup in the guide from `li-desknet-platforms` to `li-desknet-schedule`
- Added latest config for Desk-Net Schedule UI changes (filters, custom table dashboard)
- Added missing configs to reference docs
- Added li-desknet-schedule to the metadata plugins list
- Moved title sync config to the correct location
- Updated release notes