### PR TITLE
Clarify document inbox for different content types

### DIFF
--- a/content/reference-docs/project-config/content-types.md
+++ b/content/reference-docs/project-config/content-types.md
@@ -575,7 +575,7 @@ The print options allow you to enable the WoodWing Studio print connector on a c
 
 {{< added-in release-2021-11 >}}, and media library support {{< added-in release-2022-03 >}}
 
-The document inbox feature allows document and media references to be assigned to another document.
+The document inbox feature allows document and media references to be assigned to another document. Currently pages can accept documents or media library entries to their inbox, articles can only accept media library entries.
 
 ### Configuration
 
@@ -587,6 +587,18 @@ The following configuration allows the "page" content type to accept "regular" a
   // ...
   inbox: {
     contentTypes: ['regular', 'another-handle'],
+    mediaTypes: ['image', 'video']
+  }
+}
+```
+
+For regular article content types add only the mediaTypes config to accept images and videos which can be dragged directly into the document. We do not currently support other content types inside of articles. The config will look something like this:
+
+```js
+{
+  handle: 'regular',
+  // ...
+  inbox: {
     mediaTypes: ['image', 'video']
   }
 }


### PR DESCRIPTION
If regular content types are added to the inbox configs for non-page content types then they appear in the search modal and can be added to their inboxes. However, we do not yet support doing anything with them (This is planned for January 2023). As the support is incoming, rather than make the schema stricter I have instead updated the documentation to reflect the best config. This means that now the "Put into inbox" button for non page-types will only show pages (if they have an inbox set up). However, they can still receive images and videos which can then be dragged directly into the article itself. 