### PR TITLE
Update `li-transcoding-state` Default UI docs

### DIFF
--- a/content/reference-docs/document/metadata/metadata-plugin-list.md
+++ b/content/reference-docs/document/metadata/metadata-plugin-list.md
@@ -1062,7 +1062,7 @@ metadata: [
   }]
 }
 ```
-**Default UI**: UI to trigger transcodings, see progress and the result in the end (`liMetaTranscodingStateForm`)
+**Default UI**: UI to trigger transcodings, see progress and the result in the end
 
 ## li-video-reference
 


### PR DESCRIPTION
Remove the old default component name in the `li-transcoding-state` metadata plugin docs.
Related PR: https://github.com/livingdocsIO/livingdocs-editor/pull/5744