### PR TITLE
Hugo: Fix custom hugo metadata example doc

### DIFF
--- a/content/guides/integrations/hugo-dnd/index.md
+++ b/content/guides/integrations/hugo-dnd/index.md
@@ -210,28 +210,29 @@ module.exports = {
     additionalProperties: false,
     properties: {
       id: {
-        plugin: 'li-text'
+        type: 'string'
       },
       category: {
-        plugin: 'li-text'
+        type: 'string'
       },
       urgency: {
-        plugin: 'li-number'
+        type: 'string'
       },
       source: {
-        plugin: 'li-text'
+        type: 'string'
       },
       timestamp: {
-        plugin: 'li-datetime'
+        type: 'string',
+        format: 'date-time'
       },
       service: {
-        plugin: 'li-text'
+        type: 'string'
       },
       keywords: {
-        plugin: 'li-text'
+        type: 'string'
       },
       note: {
-        plugin: 'li-text'
+        type: 'string'
       }
     }
   }


### PR DESCRIPTION
The `storageSchema` is a JSON schema and not something that knows about `plugins` and our `metadata` `types`.