### PR TITLE
Update release notes [release-2022-09] to include cheerio modification PR

### DIFF
--- a/content/operations/releases/release-2022-09.md
+++ b/content/operations/releases/release-2022-09.md
@@ -295,6 +295,8 @@ Remove `ui.config.rows` config of metadata plugin `li-text`. If defined, replace
 
 ### Security
 
+* [Cheerio is now an optional dependency, downstream has to include it](https://github.com/livingdocsIO/livingdocs-server/pull/4838)
+
 ### Design
 * [Dashboards: Flatter Design](https://github.com/livingdocsIO/livingdocs-editor/pull/5605)
 


### PR DESCRIPTION
Under `security` section I included cheerio PR link. -> https://github.com/livingdocsIO/livingdocs-server/pull/4838