### PR TITLE
Update release notes to include Google vision and Translate security PR

### DIFF
--- a/content/operations/releases/release-2022-09.md
+++ b/content/operations/releases/release-2022-09.md
@@ -296,6 +296,7 @@ Remove `ui.config.rows` config of metadata plugin `li-text`. If defined, replace
 ### Security
 
 * [Cheerio is now an optional dependency, downstream has to include it](https://github.com/livingdocsIO/livingdocs-server/pull/4838)
+* [Google Vision and Google Translate are now an optional dependency, downstream has to include it](https://github.com/livingdocsIO/livingdocs-server/pull/4833)
 
 ### Design
 * [Dashboards: Flatter Design](https://github.com/livingdocsIO/livingdocs-editor/pull/5605)


### PR DESCRIPTION
Add under security section Google Vision PR link. -> https://github.com/livingdocsIO/livingdocs-server/pull/4833