### PR TITLE
Drop support for node 14

### DIFF
--- a/content/operations/releases/master.md
+++ b/content/operations/releases/master.md
@@ -66,20 +66,20 @@ These are the release notes of the upcoming release (pull requests merged to mas
 |Postgres|14|
 |Elasticsearch<br/>OpenSearch|8.x<br/>2|
 |Redis|7|
-|Livingdocs Server Docker Image|livingdocs/server-base:16|
-|Livingdocs Editor Docker Image|livingdocs/editor-base:16|
+|Livingdocs Server Docker Image|livingdocs/server-base:18|
+|Livingdocs Editor Docker Image|livingdocs/editor-base:18|
 |Browser Support|Edge >= 80, Firefox >= 74, Chrome >= 80, Safari >= 13.1, iOS Safari >= 13.4, Opera >= 67|
 
 ### Minimal
 |Name|Version|
 |-|-|
-|Node|14|
-|NPM|7|
+|Node|16|
+|NPM|8|
 |Postgres|12|
 |Elasticsearch<br/>OpenSearch|7.x<br/>1|
 |Redis|5 (Deprecated)|
-|Livingdocs Server Docker Image|livingdocs/server-base:14.3|
-|Livingdocs Editor Docker Image|livingdocs/editor-base:14.3|
+|Livingdocs Server Docker Image|livingdocs/server-base:16.3|
+|Livingdocs Editor Docker Image|livingdocs/editor-base:16.3|
 |Browser Support|Edge >= 80, Firefox >= 74, Chrome >= 80, Safari >= 13.1, iOS Safari >= 13.4, Opera >= 67|
 
 


### PR DESCRIPTION
Relations:
- Documentation: https://github.com/livingdocsIO/documentation/pull/583
- Server PR: https://github.com/livingdocsIO/livingdocs-server/pull/4954
- Editor PR: https://github.com/livingdocsIO/livingdocs-editor/pull/5990

### Changelog
- 💥 Drop support for node 14. Please upgrade to node v18.