### PR TITLE
Correct spellcheck underline release link

### DIFF
--- a/content/reference-docs/editor-extensions/editor-configuration/text-editing.md
+++ b/content/reference-docs/editor-extensions/editor-configuration/text-editing.md
@@ -327,7 +327,7 @@ Spellcheck response with corrections:
 {"status":false, "bad":[{"word":"falsch","pos":0}]}
 ```
 
-**Underline technique** ({{< added-in release-2022-03 >}})
+**Underline technique** ({{< added-in release-2022-11 >}})
 
 Misspelled text is highlighted with a dotted red underline in the editor.
 There are two ways how to render such an underline:


### PR DESCRIPTION
Fixed a copy & paste error where I added the wrong release link to the new spellcheck config that was added with release 2022-11