### PR TITLE
Remove the not supported Copy Function in document copy config

### DIFF
--- a/content/guides/editor/document-copy/index.md
+++ b/content/guides/editor/document-copy/index.md
@@ -122,9 +122,6 @@ copy: [
             //   {'from': 'tasks', 'to': 'tasks'}
             // ]
             'title', 'tasks',
-
-            // NOT IMPLEMENTED: computes the new value based on a passed function
-            {from: 'title', to: function(d) {return d.toUpperCase()}}
           ]
         },
         // a document can be transformed


### PR DESCRIPTION
We never implemented or supported this config. The docs are 6 years old. This removes unsupported suggested config