### PR TITLE
Fix first publication date

### DIFF
--- a/content/operations/releases/master.md
+++ b/content/operations/releases/master.md
@@ -10,7 +10,7 @@ aliases:
 ---
 
 {{< release-header
-  title="January 2022 Release"
+  title="January 2023 Release"
   upcoming=true
   legacy=false
   current=false
@@ -162,6 +162,47 @@ TODO: add db migrations
 # run `livingdocs-server migrate up` to update to the newest database scheme
 livingdocs-server migrate up
 ```
+
+### Fix firstPublicationDate to documents table (Post Deployment) :fire:
+
+This script was backported to release-2022-11, so it has been added again for release-2023-01 in case anyone missed it. If you already ran the script with the previous release upgrade you do not need to run it again.
+
+If you have unpublished a document while running release-2022-07 or release-2022-09 then you may have inaccurate values for the `document.systemdata.firstPublicationDate`. Below is a comparison of the change in the four most recent versions:
+
+First publish:
+release-2022-07 and release-2022-09: Set `firstPublicationDate`
+release-2022-05 and release-2022-11: Set `firstPublicationDate`
+
+Republish while published:
+release-2022-07 and release-2022-09: Keep `firstPublicationDate`
+release-2022-05 and release-2022-11: Keep `firstPublicationDate`
+
+Unpublish:
+release-2022-07 and release-2022-09: Remove `firstPublicationDate`
+release-2022-05 and release-2022-11: Keep `firstPublicationDate`
+
+Republish after unpublish:
+release-2022-07 and release-2022-09: Set `firstPublicationDate`
+release-2022-05 and release-2022-11: Keep `firstPublicationDate`
+
+Essentially the old behaviour and the new "fixed" behaviour is to set `firstPublicationDate` once and never modify it. This property will still exist even when the document is unpublished. For release-2022-07 and release-2022-09 the difference in behaviour was that the `firstPublicationDate` would be cleared on unpublish and set again at the next publish.
+
+If you would like to correct the `firstPublicationDate` property for all of your articles you can run:
+```bash
+node ./node_modules/@livingdocs/server/db/manual-migrations/009-fix-first-publication-date.js
+```
+
+This script performs the following actions:
+
+1. Check that `first_publication_id` has been set (same as the script 007-populate-first-publication-data.js)
+2. Move `firstPublicationDate` from `data` to `data.publishControl`
+3. Remove `data.firstPublicationDate`
+4. If `firstPublicationDate` is not set then use the value from the first publication
+5. If `firstPublicationDate` is set then use the value from the first publication when the first publication is older
+
+It is highly recommended that you run this script because it is performing a data migration as well as fixing the values.
+
+References: [Server PR](https://github.com/livingdocsIO/livingdocs-server/pull/4957)
 
 ## Deprecations
 

--- a/content/operations/releases/old/release-2017-08.md
+++ b/content/operations/releases/old/release-2017-08.md
@@ -233,4 +233,4 @@ In the coming September or October release we plan to introduce `contentTypes`. 
 
 With this release the `documents` database table contains a new column `content_type`. This column should be set for every document. This release ensures that every new document has a `contentType` set. If a document has a layout, the contentType will be set to the layout. Otherwise the contentType will be set to the documentType.
 
-For all existing documents a manual migration will have to be run. We created a manual migration as this is a long running operation for databases with many documents. The migration can be found in `db/manual-migrations/002-write-content-type.js`.
+For all existing documents a manual migration will have to be run. We created a manual migration as this is a long running operation for databases with many documents. The migration can be found in `./node_modules/@livingdocs/server/db/manual-migrations/002-write-content-type.js`.

--- a/content/operations/releases/old/release-2018-01.md
+++ b/content/operations/releases/old/release-2018-01.md
@@ -75,7 +75,7 @@ Before you can deploy the January release, you have to run a manual database mig
 If you have installed the `October Release 2017` or `December Release 2017`, you can execute the manual migration with
 
 ```bash
-`NODE_ENV=<env> ENVIRONMENT=<env> node node_modules/@livingdocs/server/db/manual-migrations/002-write-content-type.js`
+`NODE_ENV=<env> ENVIRONMENT=<env> node ./node_modules/@livingdocs/server/db/manual-migrations/002-write-content-type.js`
 ```
 
 

--- a/content/operations/releases/old/release-2018-02.md
+++ b/content/operations/releases/old/release-2018-02.md
@@ -55,7 +55,7 @@ How to require the editor in your package.json:
 
 ## Manual migration script to fix content types :beetle:
 
-In the current releases (january & february) the content_type column on the publication events table is missing all the data. The script db/manual-migrations/004-write-content-type-on-events-table.js inserts that data in a non-blocking script.
+In the current releases (january & february) the content_type column on the publication events table is missing all the data. The script ./node_modules/@livingdocs/server/db/manual-migrations/004-write-content-type-on-events-table.js inserts that data in a non-blocking script.
 
 We won't do a blocking migration as that might cause downtime for big customers (we'll need to find good solutions for that in the future). Please run the regular migration and after that apply the manual one. A blocking migration that makes sure that all columns are `NOT NULLABLE` will follow in the february or march release.
 

--- a/content/operations/releases/old/release-2019-07.md
+++ b/content/operations/releases/old/release-2019-07.md
@@ -339,7 +339,7 @@ And we will also gradually introduce new configuration options which can be defi
 ### Needed Actions :fire:
 - :fire: migrate the db with `livingdocs-server migrate up`
   - If there are problems with the automatic db migration you can skip it with `EXPORT SKIP_DB_MIGRATION_119=true`
-  - There is also a manual migration that will migrate projects individually in `db/manual-migrations/005-migrate-channel-config-streams.js`
+  - There is also a manual migration that will migrate projects individually in `./node_modules/@livingdocs/server/db/manual-migrations/005-migrate-channel-config-streams.js`
 - :fire: Check and update your code to not use removed functions
 
 You can find a much more detailed description of the rewrite in the [Rewrite Channel Config PR](https://github.com/livingdocsIO/livingdocs-server/pull/2432).

--- a/content/operations/releases/release-2021-03.md
+++ b/content/operations/releases/release-2021-03.md
@@ -266,7 +266,7 @@ References:
 
 As described in the [APIs](#apis-gift) section, we extend some endpoints (public API + server API) with reference information of a document. Old document references need to be converted into the new format with a manual db migration.
 
-After the release, execute the manual db migration `node node_modules/@livingdocs/server/db/manual-migrations/006-generate-references --concurrency=5`. If you have issues with memory, you can reduce the concurrency and it's also possible to run the script multiple times.
+After the release, execute the manual db migration `node ./node_modules/@livingdocs/server/db/manual-migrations/006-generate-references --concurrency=5`. If you have issues with memory, you can reduce the concurrency and it's also possible to run the script multiple times.
 
 These are the key changes/issues
 - It's a database heavy operation and should be executed outside business time (when having a lot of documents)

--- a/content/operations/releases/release-2021-06.md
+++ b/content/operations/releases/release-2021-06.md
@@ -183,7 +183,7 @@ This time we have a rather high amount of breaking changes, therefore we grouped
 
 In order for a delivery to know when a document was first published, we want to provide the firstPublicationDate when a Publication is fetched from the Public API. To be able to fullfill that goal we need a db migration.
 
-For productive systems please run a manual migration using `node ./db/manual-migrations/007-populate-first-publication-date.js` to process the documents in batches. The manual migration must be done before `livingdocs-server migrate up`, which contains the same migration, but locks the database by ~10s for 100k documents.
+For productive systems please run a manual migration using `node ./node_modules/@livingdocs/server/db/manual-migrations/007-populate-first-publication-date.js` to process the documents in batches. The manual migration must be done before `livingdocs-server migrate up`, which contains the same migration, but locks the database by ~10s for 100k documents.
 
 References: [Server PR](https://github.com/livingdocsIO/livingdocs-server/pull/3505)
 
@@ -191,7 +191,7 @@ References: [Server PR](https://github.com/livingdocsIO/livingdocs-server/pull/3
 
 Tidy-up after populating `document_revisions.metadata_id` as part of the `firstPublicationDate` feature in [Server PR](https://github.com/livingdocsIO/livingdocs-server/pull/3505)
 
-For productive systems please run a manual migration using `node ./db/manual-migrations/008-move-metadata_id.js` to process the documents in batches. The manual migration must be done before `livingdocs-server migrate up`, which contains the same migration, but locks the database. We propose to have enough disk space left for this migration (2 x used disk space by the database). After the migration, the disk space should be smaller, but during the migration, it will grow.
+For productive systems please run a manual migration using `node ./node_modules/@livingdocs/server/db/manual-migrations/008-move-metadata_id.js` to process the documents in batches. The manual migration must be done before `livingdocs-server migrate up`, which contains the same migration, but locks the database. We propose to have enough disk space left for this migration (2 x used disk space by the database). After the migration, the disk space should be smaller, but during the migration, it will grow.
 
 References: [Server PR](https://github.com/livingdocsIO/livingdocs-server/pull/3518)
 

--- a/content/operations/releases/release-2022-11.md
+++ b/content/operations/releases/release-2022-11.md
@@ -149,6 +149,45 @@ It's a simple/fast migration with no expected data losses.
 livingdocs-server migrate up
 ```
 
+### Fix firstPublicationDate to documents table :fire:
+
+If you have unpublished a document while running release-2022-07 or release-2022-09 then you may have inaccurate values for the `document.systemdata.firstPublicationDate`. Below is a comparison of the change in the four most recent versions:
+
+First publish:
+release-2022-07 and release-2022-09: Set `firstPublicationDate`
+release-2022-05 and release-2022-11: Set `firstPublicationDate`
+
+Republish while published:
+release-2022-07 and release-2022-09: Keep `firstPublicationDate`
+release-2022-05 and release-2022-11: Keep `firstPublicationDate`
+
+Unpublish:
+release-2022-07 and release-2022-09: Remove `firstPublicationDate`
+release-2022-05 and release-2022-11: Keep `firstPublicationDate`
+
+Republish after unpublish:
+release-2022-07 and release-2022-09: Set `firstPublicationDate`
+release-2022-05 and release-2022-11: Keep `firstPublicationDate`
+
+Essentially the old behaviour and the new "fixed" behaviour is to set `firstPublicationDate` once and never modify it. This property will still exist even when the document is unpublished. For release-2022-07 and release-2022-09 the difference in behaviour was that the `firstPublicationDate` would be cleared on unpublish and set again at the next publish.
+
+If you would like to correct the `firstPublicationDate` property for all of your articles you can run:
+```bash
+node ./node_modules/@livingdocs/server/db/manual-migrations/009-fix-first-publication-date.js
+```
+
+This script performs the following actions:
+
+1. Check that `first_publication_id` has been set (same as the script 007-populate-first-publication-data.js)
+2. Move `firstPublicationDate` from `data` to `data.publishControl`
+3. Remove `data.firstPublicationDate`
+4. If `firstPublicationDate` is not set then use the value from the first publication
+5. If `firstPublicationDate` is set then use the value from the first publication when the first publication is older
+
+It is highly recommended that you run this script because it is performing a data migration as well as fixing the values.
+
+References: [Server PR](https://github.com/livingdocsIO/livingdocs-server/pull/4957)
+
 ### Drop Elasticsearch v6 :fire:
 
 [Drop support for Elasticsearch v6](https://github.com/livingdocsIO/livingdocs-server/pull/4907).

--- a/content/operations/releases/release-2022-11.md
+++ b/content/operations/releases/release-2022-11.md
@@ -149,7 +149,7 @@ It's a simple/fast migration with no expected data losses.
 livingdocs-server migrate up
 ```
 
-### Fix firstPublicationDate to documents table :fire:
+### Fix firstPublicationDate to documents table (Post Deployment) :fire:
 
 If you have unpublished a document while running release-2022-07 or release-2022-09 then you may have inaccurate values for the `document.systemdata.firstPublicationDate`. Below is a comparison of the change in the four most recent versions:
 


### PR DESCRIPTION
Relations:
  - Issue: https://github.com/livingdocsIO/livingdocs-planning/issues/4767
  - Related PR's:
    - https://github.com/livingdocsIO/livingdocs-server/pull/4957
    - https://github.com/livingdocsIO/livingdocs-server/pull/4992


It would be great if you could both give the text in the latest release notes a review.

Is "Breaking Changes" the correct section? All other manual migrations have been listed here, although it's not technically a breaking change this time.

Do we need to specify pre or post deployment? I suppose post deployment makes the most sense for a fix like this.