### PR TITLE
Adding a li2Xliff guide to the documentation

### DIFF
--- a/content/guides/integrations/li2xliff/index.md
+++ b/content/guides/integrations/li2xliff/index.md
@@ -1,12 +1,20 @@
 ---
-title: Using li2xliff and CAT tools for translating Livingdocs content
+title: Assisted translation with CAT tool
 description: Configure our li2xliff library to send Livingdocs content to CAT tools
 weight: 14
 ---
 
 ## li2Xliff
 
-We have created a library which converts Livingdocs JSON to XLIFF - the XML format required by CAT tools to mark, translate and update content - and to convert XLIFF back to Livingdocs content.
+We have created a library which converts Livingdocs JSON to XLIFF - the XML format required by computer-assisted translation (CAT) tools to mark, translate and update content - and to convert XLIFF back to Livingdocs content. A CAT tool offers translators a faster and easier way to translate content and can be supported with machine translation. 
+
+The library can be found [here](https://github.com/livingdocsIO/Li2Xliff)
+
+To install:
+
+```js
+npm install @livingdocs/li2xliff
+```
 
 The library exports two functions which can be required:
 
@@ -62,6 +70,7 @@ It returns the translated content and, if there are any, an array of errors.
 
 ## Registering Translation Function
 
+To enable the functionality in Livingdocs you will need to activate multiple languages and translations. The documentation can be found [here]({{< ref "/content/reference-docs/project-config/settings.md#languages--translations" >}})
 
 In your Livingdocs Server instance you can subscribe to [server events]({{< ref "/content/reference-docs/server-extensions/server-events.md" >}}) such as document creation. Then you can send your Livingdoc content for translation.
 

--- a/content/guides/integrations/li2xliff/index.md
+++ b/content/guides/integrations/li2xliff/index.md
@@ -19,13 +19,15 @@ const {createXliff, updateContent} = require('@livingdocs/li2xliff')
 `createXliff` converts Livingdoc content to XLIFF and requires Livingdoc content and a config object:
 
 ```js
-  const xliffContent = createXliff({
-          content: documentVersion.content, // Livingdoc Content
-          config: {
-            targetLanguage: config.targetLanguage, // Required
-            srcLanguage: config.srcLanguage // Required
-          }
-        })
+  const xliffContent = createXliff(
+    {
+      content: documentVersion.content, // Livingdoc Content
+      config: {
+        targetLanguage: config.targetLanguage, // Required
+        srcLanguage: config.srcLanguage // Required
+      }
+    }
+  )
 ```
 
 The config object has two required properties, a target language and a source language (so, if you want to translate your German articles to English, your source language is German, target language is English).
@@ -33,15 +35,17 @@ The config object has two required properties, a target language and a source la
 It can be extended with the following optional configs:
 
 ```js
-excludeEditables: [{
+excludeEditables: [
+  {
     component: 'title',
     editables: ['title', 'author'] // this will not translate title or author editables inside title components
     },
     {
     component: 'header',
     editables: ['title'] // this will not translate titles inside header components
-    }],
-  excludeTags: ['strong', 'a'] // this will translate content inside of strong and anchor tags, but will not preserve the formatting
+  }
+],
+excludeTags: ['strong', 'a'] // this will translate content inside of strong and anchor tags, but will not preserve the formatting
 ```
 
 To exclude certain editables you must define a parent component for each editable to be excluded. To exclude tags simply define an array of formatting tags you would not like to appear in the translated document.

--- a/content/reference-docs/project-config/settings.md
+++ b/content/reference-docs/project-config/settings.md
@@ -277,6 +277,8 @@ Livingdocs allows you to define documents in multiple languages as well as integ
 
 If you activate the translation feature, then the `language` metadata plugin on a document will contain a `groupId`. You can use this in the `languageGroupId` parameter of the [Publication Search public API](https://edit.livingdocs.io/public-api) (under "Search Publications") call to retrieve all translations of a document.
 
+If you want to use a computer assisted translation (CAT) tool to translate livingdocs content you can install our li2xliff library to convert documents to XLIFF for translation and register server hooks to update content. You can follow our in-depth guide [here](add guide link)
+
 ## Integrations
 
 In general all integrations are under the `integrations` key. We still have some legacy markup where the integration is directly on the root (`desknet`), but this will be moved in the future.

--- a/content/reference-docs/project-config/settings.md
+++ b/content/reference-docs/project-config/settings.md
@@ -277,7 +277,8 @@ Livingdocs allows you to define documents in multiple languages as well as integ
 
 If you activate the translation feature, then the `language` metadata plugin on a document will contain a `groupId`. You can use this in the `languageGroupId` parameter of the [Publication Search public API](https://edit.livingdocs.io/public-api) (under "Search Publications") call to retrieve all translations of a document.
 
-If you want to use a computer assisted translation (CAT) tool to translate livingdocs content you can install our li2xliff library to convert documents to XLIFF for translation and register server hooks to update content. You can follow our in-depth guide [here](add guide link)
+If you want to use a computer assisted translation (CAT) tool to translate livingdocs content you can install our li2xliff library to convert documents to XLIFF for translation and list to [server events]({{< ref "/content/reference-docs/server-extensions/server-events.md" >}}) to update content. You can follow our in-depth guide [here]({{< ref "/content/guides/integrations/li2xliff/index.md" >}})
+
 
 ## Integrations
 


### PR DESCRIPTION
We have built our installable li2Xliff guide to offer CAT translations for customers. This is implemented by the NZZ. 

I have tried to write as simple a guide as possible but with enough detail. There are links to the webhook and access-hook docs as these are required to implement it. I have given example functions for these, but otherwise kept it simple on the configs you can hand li2xliff and what these configs do. 