### PR TITLE
Remove documentation of history statistics

### DIFF
--- a/content/customising/advanced/editor-configuration/editing-features.md
+++ b/content/customising/advanced/editor-configuration/editing-features.md
@@ -141,16 +141,12 @@ See [here]({{< ref "./text-editing.md#spellcheck" >}})
 ```js
 {
   app: {
-    useHistoryStatistics: true,
     useHistoryRestore: true
   }
 }
 ```
 
-The `useHistoryStatistics` option will show a small statistics/activity panel at the top of the document history sidebar.
 The `useHistoryRestore` option enables / disables the restore functionality in the document history, i.e. the ability to restore the opened document to an older revision.
-
-Both options are recommended.
 
 ### Diff View
 ```js


### PR DESCRIPTION
Seems this has gone out of our codebase quite a while ago. Unfortunately, it was still in the docs and in pretty much every editor config ...