### PR TITLE
Copy unknown components config removed from copy/transform documentation

### DIFF
--- a/content/guides/editor/document-copy/index.md
+++ b/content/guides/editor/document-copy/index.md
@@ -205,12 +205,7 @@ module.exports = {
   // useful if the other options in the copy API are too limiting
   afterConversion: ({sourceMetadata, convertedDocument}) => {
     return doCustomStuff({sourceMetadata, convertedDocument})
-  },
-
-  // true = copy the component, even when the target contentType doesn't know the component
-  // false = ignore a component when the target contentType doesn't know the component
-  // NOT IMPLEMENTED: currently everything will be copied (is the same as `true`)
-  copyUnknownComponents: false
+  }
 }
 ```
 


### PR DESCRIPTION
Whilst supporting Dumont on a custom copy function I suggested using this config but from the comment it seems we never enabled it - Lorenzo also searched the server, editor and framework and said we never configured it. 

So I thought it was worth removing from the docs as it is misleading to have a config which we know does nothing. 