### PR TITLE
Align anchor on public api section titles

### DIFF
--- a/themes/hugo-docs/assets/elements/api-example.scss
+++ b/themes/hugo-docs/assets/elements/api-example.scss
@@ -12,6 +12,11 @@ $api-example-padding: $space-m;
     padding-bottom: $space-m;
     margin-top: 0;
     border-bottom: 1px solid $color-grey-6;
+
+    .anchor {
+      top: 15px;
+      left: -17px;
+    }
   }
 
   .highlight {

--- a/themes/hugo-docs/layouts/shortcodes/api-example.html
+++ b/themes/hugo-docs/layouts/shortcodes/api-example.html
@@ -50,7 +50,7 @@
             <div class="code-teaser__endpoint">Curl Example</div>
           </div>
         </div>
-  
+
         <div class="teaser-and-code__code">
           {{- $query -}}
         </div>
@@ -84,7 +84,7 @@
                 <div class="code-teaser__interaction">
                   <span class="arrow arrow--right"></span>
                 </div>
-                
+
                 <div class="code-teaser__code">{{ $code }}</div>
                 {{- if (eq $code "200") -}}<div class="code-teaser__name">OK</div>{{- end -}}
                 {{- if (eq $code "301") -}}<div class="code-teaser__name">Moved Permanently</div>{{- end -}}
@@ -107,5 +107,5 @@
 
     </div>
   {{- end -}}
-  
+
 </div>


### PR DESCRIPTION
Before:
<img width="379" alt="image" src="https://user-images.githubusercontent.com/431376/222435319-583d075b-9a56-4526-a1d5-920965353d91.png">

After:
<img width="399" alt="image" src="https://user-images.githubusercontent.com/431376/222435411-7ceb2e44-1f54-4250-92eb-27ebcf31a7da.png">
