### PR TITLE
fix: rename Release Notes to Technical Release Notes

### DIFF
--- a/content/operations/releases/_index.md
+++ b/content/operations/releases/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Release Notes
-linkTitle: Release Notes
+title: Technical Release Notes
+linkTitle: Technical Release Notes
 description: Check out our future, present and past releases in detail.
 icon: alert-decagram
 menu: operations
@@ -12,7 +12,7 @@ Subscribe to the release newsletter to get notified with a rundown of the latest
 
 {{< newsletter-form >}}
 
-## Release Notes
+## Technical Release Notes
 
 * **Current Release**: The latest announced release
 * **Maintained Releases**: Get security fixes and severe bug fixes.

--- a/themes/hugo-docs/layouts/partials/topbar.html
+++ b/themes/hugo-docs/layouts/partials/topbar.html
@@ -19,11 +19,11 @@
     <ul class="shortcuts">
       {{ if in .Page.Permalink "/releases/" }}
         <li class="shortcut shortcut--active">
-          <a class="shortcut__link" href="/operations/releases/">Release Notes</a>
+          <a class="shortcut__link" href="/operations/releases/">Technical Release Notes</a>
         </li>
       {{ else }}
         <li class="shortcut">
-          <a class="shortcut__link" href="/operations/releases/">Release Notes</a>
+          <a class="shortcut__link" href="/operations/releases/">Technical Release Notes</a>
         </li>
       {{ end }}
       <li class="shortcut">


### PR DESCRIPTION
As discussed/decided we want to call the Technical Release Notes in the Documentation `Technical Release Notes`. 