### PR TITLE
Add the `fieldExtractorOnPage` config to the docs

### DIFF
--- a/content/reference/document/document-design/_index.md
+++ b/content/reference/document/document-design/_index.md
@@ -509,6 +509,13 @@ fieldExtractor: [
 ]
 ```
 
+By default the field extractor is not enabled for pages. You can configure it in the global editor config with the following field in the metadata object: 
+```
+  metadata: {
+    fieldExtractorOnPage: true
+  }
+  ```
+
 **Properties**
 - `identifier` - metadata field handle, you want to sync to
 - `type` data type


### PR DESCRIPTION
Atilla at appsfactory asked why the field extractor didn't work on pages. We listen to a global editor config so I have added it to the docs. 