### PR TITLE
Update delivery build documentation

### DIFF
--- a/content/guides/editor/publish-control/delivery/index.md
+++ b/content/guides/editor/publish-control/delivery/index.md
@@ -1,14 +1,16 @@
 ---
-title: Publication Delivery
-description: Trigger deliveries and see delivery build status.
+title: Delivery Builds
+description: Trigger builds for specific deliveries and show the delivery build status in the Editor.
 weight: 6
 ---
 
-For infinite products like an e-paper there is usually a “build” stage involved. With the new Deliveries feature we allow a user to trigger a remote system to kick off a delivery build and report the status of the build back to Livingdocs. This allows an editor to get a better view on the infinite product life cycle. These are the features:
+For finite products like an e-paper there is usually a “build” stage involved. With the new Deliveries feature we allow a user to trigger a remote system to kick off a delivery build and report the status of the build back to Livingdocs. This allows an editor to get a better view on the finite product life cycle. These are the features:
 
 ![delivery](./delivery.png)
 
-As soon as the document has been published, the delivery section will show up. Clicking on the build button will trigger the [Webhook]({{< ref "/reference/webhooks" >}}) `document.build` which in turn will trigger the delivery build in the external system, as configured in the Project Config `settings`.
+## Delivery Builds for publications
+
+The delivery section in the Publish Panel will show delivery builds for the current document once it is published. Clicking on the build button will trigger the [Webhook]({{< ref "/reference/webhooks" >}}) `document.build` which in turn will trigger the delivery build in the external system, as configured in the Project Config `settings`.
 The external build system can report back the current build status with an optional message via public API. The status and an optional message are reflected in the delivery section of the Publish Control, as seen above.
 
 Update the status (from an external system) back to Livingdocs:
@@ -21,7 +23,7 @@ Payload:
 {
   "reportId": "2SG2MAA9RwPn",
   "publicationId": 524,
-  "deliveryHandle": "mobile",
+  "deliveryHandle": "web",
   "status": "success",
   "message": "More info see <a href=\"https://google.ch\" target=\"_blank\">here</a>"
 }
@@ -85,6 +87,7 @@ Configure the available deliveries for this project and optionally customize the
       },
       build: {
         enabled: true,
+        type: 'publication',
         triggerButtonLabel: 'Build',
         retriggerButtonLabel: 'Build again',
         retryButtonLabel: 'Retry'
@@ -112,4 +115,54 @@ Configure which data-records have a build button and build status in the publish
   ]
 }
 
+```
+
+## Delivery Builds for Drafts
+
+You can also configure delivery builds for drafts. These are available before a document is published and no `publicationId` is tracked in the build status.
+
+These are the differences of a draft build:
+
+Use `type: 'draft'` in the delivery config:
+
+```js
+build: {
+  enabled: true,
+  type: 'draft',
+  triggerButtonLabel: 'Build',
+  retriggerButtonLabel: 'Build again',
+  retryButtonLabel: 'Retry'
+}
+```
+
+Use the event name `document.build.draft` in the webhook config:
+
+```js
+events: [
+  {
+    name: 'document.build.draft',
+    conditions: {
+      deliveryHandles: ['draftDelivery']
+    }
+  }
+]
+```
+
+The webhook works the same as for delivery builds of type `publication` but there will be no publicationId in the event even if the document is published.
+
+This also means when you report your status you don't have to include the `publicationId` in your request.
+
+Here is an example:
+
+`POST /api/v1/documents/360/addDeliveryStatus`
+
+Payload:
+
+```json
+{
+  "reportId": "2SG2MAA9RwPn",
+  "deliveryHandle": "draftDelivery",
+  "status": "success",
+  "message": "More info see <a href=\"https://google.ch\" target=\"_blank\">here</a>"
+}
 ```

--- a/content/reference/project-config/deliveries.md
+++ b/content/reference/project-config/deliveries.md
@@ -5,14 +5,17 @@ menus:
   reference:
     parent: Project Config
 ---
-You can configure `deliveries` to let Livingdocs know something about the delivery/deliveries you operate.
+You can configure `deliveries` to specify one or multiple applications which render Livingdocs content.
 
-As of December 2020 this is used to enable the `Internal Document Links` feature.
+The deliveries can be used to configure these functionalities:
+- Enable the `Internal Document Links` feature.
+- Enable Publication and Draft Builds
 
 An example:
 ```js
 // deliveries is configured at projectConfig.deliveries
 deliveries: [
+  // Example with a delivery build and internal links
   {
     handle: 'web',
     label: 'Website',
@@ -29,11 +32,13 @@ deliveries: [
     // optionally customize the build button
     build: {
       enabled: true,
+      type: 'publication',
       triggerButtonLabel: 'Build',
       retriggerButtonLabel: 'Build again',
       retryButtonLabel: 'Retry'
     }
   },
+  // Example which only supports internal links
   {
     handle: 'app',
     label: 'App',
@@ -46,7 +51,10 @@ deliveries: [
 ]
 ```
 
-## pathPattern
+## Enable Internal Links
+
+### pathPattern
+
 The `Internal Document Links` feature will construct a URL to a document based on these placeholders:
 
 - `:id` (document.id, always available)
@@ -57,7 +65,53 @@ This URL is then inserted into to `a` tags `href` attribute within the document.
 Additionally a `data-li-document-ref` attribute is written containing the `document.id`.
 
 ### Caveats
+
 Since the `Internal Document Links` is specifically handy to link to not yet published documents you want to validate these links somewhere in your delivery to remove the ones pointing to not yet published documents.
 As this feature works on unpublished documents, Livingdocs cannot resolve the `routing` information from the [Routing System]({{< ref "/guides/organisation/routing-system.md" >}}) since this stores the information on publish which makes it unavailable before a document is published.
 
 To have the `Internal Document Links` feature be able to construct working `href` attributes, you need a routing system in your delivery that is able to redirect a user do a valid document URL based on the `document.id` and `document.projectId` only.
+
+## Delivery Builds for Publications
+
+A publication build adds a button to the Publish Panel which can be used to trigger a webhook event. This can be used to export publications to third party systems on demand or also to render previews externally and send a feedback with a link back to the Livingdocs Editor which users can click.
+
+You configure a publication build for a delivery by adding a `build` property.
+
+```js
+build: {
+  enabled: true,
+  type: 'publication',
+  triggerButtonLabel: 'Build',
+  retriggerButtonLabel: 'Build again',
+  retryButtonLabel: 'Retry'
+}
+```
+Notes for the labels:
+- `triggerButtonLabel`: Shown when there is no build for the current publication
+- `retriggerButtonLabel`: Shown when a build for the current publication exists
+- `retryButtonLabel`: Shown when the last build failed due to an error.
+
+The Publication Build UI will only be visible in the Editor once a document is published. And webhook events will include a publicationId.
+
+To see publication builds on a document you will also need to configure `deliveries` on the [contentType]({{< ref "./content-types.md" >}}) config.
+
+## Delivery Builds for Drafts
+
+Draft Builds are the same as Publication builds except they are always available, even before a document is published.
+
+For details see the Publication Builds section above.
+
+Example Configuration
+```js
+build: {
+  enabled: true,
+  type: 'draft',
+  triggerButtonLabel: 'Build Preview',
+  retriggerButtonLabel: 'Build Preview again',
+  retryButtonLabel: 'Retry'
+}
+```
+
+## Further Reading: Delivery Build Guide
+
+Here you find the [Delivery Build Guide]({{< ref "../../guides/editor/publish-control/delivery" >}}) which explains the setup of delivery builds in more detail.

--- a/content/reference/webhooks/_index.md
+++ b/content/reference/webhooks/_index.md
@@ -73,6 +73,7 @@ webhooks: {
 - `document.unpublish`
 - `document.update`
 - `document.build`
+- `document.build.draft`
 - `mediaLibraryEntry.create`
 - `mediaLibraryEntry.archive`
 - `mediaLibraryEntry.revoke`
@@ -168,6 +169,20 @@ Here is an example payload sent to your url set in the Webhook configuration.
   "webhookHandle": "handle",
   "documentId": 179,
   "publicationId": 322,
+  "deliveryHandle": "web",
+  "reportId": "2SG2MAA9RwPn"
+}
+```
+
+`document.build.draft`
+```json
+{
+  "event": "document.build",
+  "deliveryId": "2Xwe-gvuB_JsK3_4bJerT",
+  "projectId": 3,
+  "projectHandle": "service",
+  "webhookHandle": "handle",
+  "documentId": 179,
   "deliveryHandle": "web",
   "reportId": "2SG2MAA9RwPn"
 }


### PR DESCRIPTION
## Changelog

- 🎁 Add documentation for draft delivery builds
- 💎 Update existing configuration for builds and use 'delivery builds' as a name for this feature