### PR TITLE
fix(includes): moved paramschema to be more prominent

### DIFF
--- a/content/reference/document/includes/server-customization.md
+++ b/content/reference/document/includes/server-customization.md
@@ -28,6 +28,8 @@ liServer.features.register('include-services', async function (feature, server) 
 
 `paramsSchema` allows you to generate UI sidebar options in the Editor for Includes. With that you can choose and pass these options to influence the rendering. Look into this [Overview]({{< ref "reference/document/metadata/metadata-plugin-list#overview">}}) to see what plugins are supported for Includes.
 
+If you want to be able to load document metadata and content it's important to set `preload: true`. 
+
 ```js
 module.exports = {
   name: 'teaser',


### PR DESCRIPTION
After writing some paramsSchema includes as part of Bluewin BTS and infobox improvements, along with supporting Netcetera writing ones with li-document-reference/s, I wanted to just tidy up the documentation a little bit. 

I moved the paramsSchema to the top to try and promote it as the most viable option. And reminded users not to write any custom code without talking to us first. 

I also added the option of rendering a publication in the renderFunction. 

Happy to discuss 👍 