### PR TITLE
fix(server hooks): preunpublishhook added to table

### DIFF
--- a/content/customising/server/server-hooks.md
+++ b/content/customising/server/server-hooks.md
@@ -38,6 +38,7 @@ With publication hooks you can influence the [`Document Publication Lifecycle`](
 |preparePublishHookAsync|Instant Publish|✅|release-2022-03||
 |prepublishHookAsync|Instant Publish|✅||release-2022-03|
 |publishHookAsync|Instant Publish|✅||release-2022-03|
+|preUnpublishHookAsync|Instant Publish|✅||release-2022-05|
 |postPublishHookAsync|Instant Publish||release-2022-03||
 |unpublishHookAsync|Instant Publish|✅|release-2017-01|release-2022-05|
 |postUnpublishHookAsync|Instant Publish|✅|release-2022-05||


### PR DESCRIPTION
Added the preUnpublishHookAsync to the table of publish hooks. 

The rest of the documentation is pretty good IMO, but I don't know if we can make it possible to search for hooks in the documentation search bar. As it is, 'preparepublishhook' or any other function name don't return anything. Any ideas @DaRaFF ?