### PR TITLE
fix(transcoding plugin): component removed

### DIFF
--- a/content/guides/media-library/media-library-setup/index.md
+++ b/content/guides/media-library/media-library-setup/index.md
@@ -526,10 +526,7 @@ module.exports = {
     // ...
     {
       handle: 'transcoding',
-      type: 'li-transcoding-state',
-      ui: {
-        component: 'liMetaTranscodingStateForm'
-      }
+      type: 'li-transcoding-state'
     }
   ],
   // ...


### PR DESCRIPTION
Muhamet at Centralsoft sent me a message as he noticed that we removed the ui.component config for this plugin in the [november release](https://docs.livingdocs.io/operations/releases/release-2022-11/#break-metadata-plugin-li-desknet-integration--li-transcoding-state-), but it was still in the docs. 

This PR just removes it from the example config. 