### PR TITLE
Organise drafts and search

### DIFF
--- a/content/operations/releases/release-2022-03.md
+++ b/content/operations/releases/release-2022-03.md
@@ -697,7 +697,7 @@ References:
 🎁 Added new publicApi endpoint `GET /api/beta/documents/:documentId/latestDraft` to get the latest draft of a document
 
 References:
-- [Documentation]({{< ref "/reference/public-api/publications/latest-draft-beta" >}})
+- [Documentation]({{< ref "/reference/public-api/drafts/latest-draft-beta" >}})
 - [Server PR](https://github.com/livingdocsIO/livingdocs-server/pull/4224)
 
 ### Server Config

--- a/content/reference/public-api/drafts/_index.md
+++ b/content/reference/public-api/drafts/_index.md
@@ -1,0 +1,8 @@
+---
+title: Drafts
+renderTOC: false
+weight: 5
+menus:
+  reference:
+    parent: Public API
+---

--- a/content/reference/public-api/drafts/latest-draft-beta.md
+++ b/content/reference/public-api/drafts/latest-draft-beta.md
@@ -5,7 +5,7 @@ weight: 8
 renderTOC: false
 menus:
   reference:
-    parent: Publications 
+    parent: Drafts
 ---
 
 {{< api-example

--- a/content/reference/public-api/publications/_index.md
+++ b/content/reference/public-api/publications/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Publications 
+title: Publications
 renderTOC: false
 weight: 4
 menus:

--- a/content/reference/public-api/publications/latest-publication-beta.md
+++ b/content/reference/public-api/publications/latest-publication-beta.md
@@ -5,7 +5,7 @@ weight: 2
 renderTOC: false
 menus:
   reference:
-    parent: Publications 
+    parent: Publications
 ---
 
 {{< api-example

--- a/content/reference/public-api/publications/latest-publication.md
+++ b/content/reference/public-api/publications/latest-publication.md
@@ -4,7 +4,7 @@ weight: 1
 renderTOC: false
 menus:
   reference:
-    parent: Publications 
+    parent: Publications
 ---
 
 {{< api-example

--- a/content/reference/public-api/publications/latest-publications-beta.md
+++ b/content/reference/public-api/publications/latest-publications-beta.md
@@ -5,7 +5,7 @@ weight: 4
 renderTOC: false
 menus:
   reference:
-    parent: Publications 
+    parent: Publications
 ---
 
 {{< api-example

--- a/content/reference/public-api/publications/latest-publications.md
+++ b/content/reference/public-api/publications/latest-publications.md
@@ -4,7 +4,7 @@ weight: 3
 renderTOC: false
 menus:
   reference:
-    parent: Publications 
+    parent: Publications
 ---
 
 {{< api-example

--- a/content/reference/public-api/publications/publication-events.md
+++ b/content/reference/public-api/publications/publication-events.md
@@ -4,7 +4,7 @@ weight: 5
 renderTOC: false
 menus:
   reference:
-    parent: Publications 
+    parent: Publications
 ---
 
 {{< api-example

--- a/content/reference/public-api/publications/references.md
+++ b/content/reference/public-api/publications/references.md
@@ -4,7 +4,7 @@ weight: 6
 renderTOC: false
 menus:
   reference:
-    parent: Publications 
+    parent: Publications
 ---
 
 {{< api-example

--- a/content/reference/public-api/publications/renditions.md
+++ b/content/reference/public-api/publications/renditions.md
@@ -4,7 +4,7 @@ weight: 7
 renderTOC: false
 menus:
   reference:
-    parent: Publications 
+    parent: Publications
 ---
 
 {{< api-example

--- a/content/reference/public-api/publications/search.md
+++ b/content/reference/public-api/publications/search.md
@@ -1,10 +1,10 @@
 ---
 title: Search
-weight: 5
+weight: 8
 renderTOC: false
 menus:
   reference:
-    parent: Public API
+    parent: Publications 
 ---
 
 {{< api-example

--- a/content/reference/public-api/publications/search.md
+++ b/content/reference/public-api/publications/search.md
@@ -4,7 +4,7 @@ weight: 8
 renderTOC: false
 menus:
   reference:
-    parent: Publications 
+    parent: Publications
 ---
 
 {{< api-example

--- a/redirects.map
+++ b/redirects.map
@@ -83,3 +83,4 @@
 /enterprise/guides/sitemaps-and-feeds /guides/organisation/sitemaps-and-feeds/;
 /enterprise/guides/auth /guides/authentication/;
 /reference/public-api/publications/latest-draft-beta /reference/public-api/drafts/latest-draft-beta/;
+/reference/public-api/search /reference/public-api/publications/search/;

--- a/redirects.map
+++ b/redirects.map
@@ -82,3 +82,4 @@
 /enterprise/guides/elasticsearch-indexing/custom-index /guides/search/custom-index/;
 /enterprise/guides/sitemaps-and-feeds /guides/organisation/sitemaps-and-feeds/;
 /enterprise/guides/auth /guides/authentication/;
+/reference/public-api/publications/latest-draft-beta /reference/public-api/drafts/latest-draft-beta/;


### PR DESCRIPTION
- Search is within the Publications path (api/v1/publications/search), so the file and menu location have been moved.
- Latest Draft Beta is not part of Publications, so the file and menu location have been moved.
- Setting a menu parent to "Publications " instead of "Publications" creates a different menu item. I had to copy/paste to figure out why it wasn't working as expected. I don't think there was a reason for this trailing space, so I removed it.
- I have setup nginx redirects for the two moved pages.