### PR TITLE
fix(image config): remove max file size

### DIFF
--- a/content/customising/server-configuration/_index.md
+++ b/content/customising/server-configuration/_index.md
@@ -962,7 +962,6 @@ mediaLibrary: {
     },
     processing: {
       maxResolution: 24 * 1000 * 1000, // 24MP,  default 24 mega-pixels
-      maxFileSize: '15mb',
       maxConcurrentProcesses: 5, // default 5
       lossy: {
         // max pixel width or height


### PR DESCRIPTION
I removed this from the processing object for clarity that it should only be in one place - the uploadRestrictions. 

I updated the information in the testrail case and re-tested and it works 👍 