### PR TITLE
`ui.component` removal wasn't merged, it will be done next release

### DIFF
--- a/content/operations/releases/release-2023-07.md
+++ b/content/operations/releases/release-2023-07.md
@@ -88,10 +88,6 @@ Please also make sure that `document.title` is no longer accessed in custom code
 * [Server: Remove `useAsTitle`](https://github.com/livingdocsIO/livingdocs-server/pull/5763)
 * [Editor: Remove `useAsTitle`](https://github.com/livingdocsIO/livingdocs-editor/pull/6949)
 
-### Removal `ui.component`
-
-🔥 Configuring `ui.component` for metadata plugins does not work anymore.
-
 ### Rename searchPublications property `conditions` to `filters`
 
 🔥 Rename `conditions` property to `filters`


### PR DESCRIPTION
I was confused by Sublime merge search :) There are commits for `ui.component` removal but have not been merged: https://github.com/livingdocsIO/livingdocs-server/pull/5811