### PR TITLE
Remove newline after `< release >` shortcode

### DIFF
--- a/content/reference/document/metadata/plugins/li-text.md
+++ b/content/reference/document/metadata/plugins/li-text.md
@@ -31,7 +31,7 @@ contentTypeConfig: |2
           recommendedMinLength: 110,               // optional, added in release-2022-09
           recommendedMaxLength: 150,               // optional, added in release-2022-09
           allowNewlines: false,                    // default: undefined, added in release-2022-09, validated if set. Effect on ui: newlines are stripped uf not true and ui.config.rows is undefined and ui.component is not liMetaTextareaForm
-          useAsTitle: true,                        // optional, removed in {{<release release-2023-07 >}}, migrate to `displayTitlePattern`
+          useAsTitle: true,                        // optional, removed in {{< release "release-2023-07" >}}, migrate to `displayTitlePattern`
           translatable: true,                      // optional, default: false, translations are only supported for data-record and mediaLibrary
           dataProvider: {                          // optional
             // Option 1 - list of items

--- a/themes/hugo-docs/layouts/shortcodes/release.html
+++ b/themes/hugo-docs/layouts/shortcodes/release.html
@@ -1,3 +1,4 @@
 {{- $release := .Get 0 -}}
 {{- $href := print "/operations/releases/" $release "/" -}}
 <a href="{{ $href }}"><code>{{ $release }}</code></a>
+{{- /* Kill the newline! (Otherwise it will appear in the rendered markup) */ -}}


### PR DESCRIPTION
The `< release >` shortcode should be inline, but the trailing newline in the template caused the text to wrap. Using `{{- -}}` instead of `{{ }}` is used to remove any newlines surrounding the code block. 
Before:
![image](https://github.com/livingdocsIO/documentation/assets/5101376/bd94d4e4-b35e-4bca-a083-7b4fceb59737)

After:
![image](https://github.com/livingdocsIO/documentation/assets/5101376/c3242273-f23c-4334-a8f0-c6eee562e0bc)