### PR TITLE
Add mediaLibrary.image.processing.failOn to server config

### DIFF
--- a/content/customising/server-configuration/_index.md
+++ b/content/customising/server-configuration/_index.md
@@ -958,6 +958,7 @@ mediaLibrary: {
       maxFileSize: '15mb',
     },
     processing: {
+      failOn: 'warning', // 'warning' | 'error' | 'truncated' | 'none'
       maxResolution: 24 * 1000 * 1000, // 24MP,  default 24 mega-pixels
       maxConcurrentProcesses: 5, // default 5
       lossy: {


### PR DESCRIPTION
Relations:
 - Related PR: https://github.com/livingdocsIO/livingdocs-server/pull/5909