### PR TITLE
Separate search strings on any non-word character

### DIFF
--- a/themes/hugo-docs/assets/search.js
+++ b/themes/hugo-docs/assets/search.js
@@ -1,5 +1,11 @@
 const lunr = require('lunr')
 
+// Separate on any non-word value so that functions in code blocks will be returned in the results.
+// A search for "registerInitializedHook" would not find `liServer.registerInitializedHook(async`.
+// Original value: /[\s\-]+/
+lunr.tokenizer.separator = /[\W]+/
+lunr.QueryLexer.termSeparator = lunr.tokenizer.separator
+
 const indexes = {}
 const byRef = new Map()
 


### PR DESCRIPTION
Relations:
- Related PR: https://github.com/livingdocsIO/documentation/pull/710


This allows matches for "registerInitializedHook", when previously you would need to search for "liServer.registerInitializedHook".

This needs some testing before merging.