### PR TITLE
Show last year of releases in search results

### DIFF
--- a/content/operations/releases/release-2022-07.md
+++ b/content/operations/releases/release-2022-07.md
@@ -3,7 +3,7 @@ type: release-notes
 title: July 2022 Release
 description: Release notes for release-2022-07
 hideSectionTeaser: true
-excludeFromSearch: false
+excludeFromSearch: true
 aliases:
   - /operations/releases/release-2022-07/release-2022-07/
 ---

--- a/content/operations/releases/release-2023-07.md
+++ b/content/operations/releases/release-2023-07.md
@@ -2,7 +2,7 @@
 type: release-notes
 title: July 2023 Release
 description: Technical Release Notes for release-2023-07
-excludeFromSearch: true
+excludeFromSearch: false
 hideSectionTeaser: true
 aliases:
   - /operations/releases/release-2023-07/


### PR DESCRIPTION
The July 2023 release should now be visible in search. It looks like we only keep the last year visible, as release-2022-05 was already hidden from search results, so I've excluded release-2022-07 too.