### PR TITLE
Bump browser versions from march to november releases

### DIFF
--- a/content/operations/releases/release-2023-03.md
+++ b/content/operations/releases/release-2023-03.md
@@ -40,7 +40,7 @@ aliases:
 |Redis|7|
 |Livingdocs Server Docker Image|livingdocs/server-base:18.3|
 |Livingdocs Editor Docker Image|livingdocs/editor-base:18.5|
-|Browser Support|Edge >= 80, Firefox >= 74, Chrome >= 80, Safari >= 13.1, iOS Safari >= 13.4, Opera >= 67|
+| Browser Support                | Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78 |
 
 ### Minimal
 |Name|Version|
@@ -52,7 +52,7 @@ aliases:
 |Redis|6.2|
 |Livingdocs Server Docker Image|livingdocs/server-base:16.3|
 |Livingdocs Editor Docker Image|livingdocs/editor-base:16.3|
-|Browser Support|Edge >= 80, Firefox >= 74, Chrome >= 80, Safari >= 13.1, iOS Safari >= 13.4, Opera >= 67|
+| Browser Support                | Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78 |
 
 
 ## Highlights

--- a/content/operations/releases/release-2023-07.md
+++ b/content/operations/releases/release-2023-07.md
@@ -45,7 +45,7 @@ To learn about the necessary actions to update Livingdocs to `release-2023-07`, 
 | Redis                          | 7                                                                                        |
 | Livingdocs Server Docker Image | livingdocs/server-base:20                                                                |
 | Livingdocs Editor Docker Image | livingdocs/editor-base:20                                                                |
-| Browser Support                | Edge >= 80, Firefox >= 74, Chrome >= 80, Safari >= 13.1, iOS Safari >= 13.4, Opera >= 67 |
+| Browser Support                | Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78 |
 
 ### Minimal
 
@@ -58,7 +58,7 @@ To learn about the necessary actions to update Livingdocs to `release-2023-07`, 
 | Redis                          | 6.2                                                                                      |
 | Livingdocs Server Docker Image | livingdocs/server-base:18.3                                                              |
 | Livingdocs Editor Docker Image | livingdocs/editor-base:18.5                                                              |
-| Browser Support                | Edge >= 80, Firefox >= 74, Chrome >= 80, Safari >= 13.1, iOS Safari >= 13.4, Opera >= 67 |
+| Browser Support                | Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78 |
 
 ## Breaking Changes 🔥
 

--- a/content/operations/releases/release-2023-09.md
+++ b/content/operations/releases/release-2023-09.md
@@ -50,7 +50,7 @@ To learn about the necessary actions to update Livingdocs to `release-2023-09`, 
 | Redis                          | 7                                                                                        |
 | Livingdocs Server Docker Image | livingdocs/server-base:20                                                                |
 | Livingdocs Editor Docker Image | livingdocs/editor-base:20                                                                |
-| Browser Support                | Edge >= 80, Firefox >= 74, Chrome >= 80, Safari >= 13.1, iOS Safari >= 13.4, Opera >= 67 |
+| Browser Support                | Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78 |
 
 ### Minimal
 
@@ -63,7 +63,7 @@ To learn about the necessary actions to update Livingdocs to `release-2023-09`, 
 | Redis                          | 6.2                                                                                      |
 | Livingdocs Server Docker Image | livingdocs/server-base:18.3                                                              |
 | Livingdocs Editor Docker Image | livingdocs/editor-base:18.5                                                              |
-| Browser Support                | Edge >= 80, Firefox >= 74, Chrome >= 80, Safari >= 13.1, iOS Safari >= 13.4, Opera >= 67 |
+| Browser Support                | Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78 |
 
 
 ## Breaking Changes 🔥

--- a/content/operations/releases/release-2023-11.md
+++ b/content/operations/releases/release-2023-11.md
@@ -53,11 +53,29 @@ To learn about the necessary actions to update Livingdocs to `release-2023-11`, 
 
 ### Suggested
 
-TODO
+| Name                           | Version                                                                                  |
+| ------------------------------ | ---------------------------------------------------------------------------------------- |
+| Node                           | 20                                                                                       |
+| NPM                            | 9                                                                                        |
+| Postgres                       | 15                                                                                       |
+| Elasticsearch<br/>OpenSearch   | 8.x<br/>v2.3.0                                                                           |
+| Redis                          | 7                                                                                        |
+| Livingdocs Server Docker Image | livingdocs/server-base:20                                                                |
+| Livingdocs Editor Docker Image | livingdocs/editor-base:20                                                                |
+| Browser Support                | Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78 |
 
 ### Minimal
 
-TODO
+| Name                           | Version                                                                                  |
+| ------------------------------ | ---------------------------------------------------------------------------------------- |
+| Node                           | 18                                                                                       |
+| NPM                            | 9                                                                                        |
+| Postgres                       | 13                                                                                       |
+| Elasticsearch<br/>OpenSearch   | 7.x<br/>1                                                                                |
+| Redis                          | 6.2                                                                                      |
+| Livingdocs Server Docker Image | livingdocs/server-base:18.3                                                              |
+| Livingdocs Editor Docker Image | livingdocs/editor-base:18.5                                                              |
+| Browser Support                | Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78 |
 
 ## Breaking Changes 🔥
 


### PR DESCRIPTION
Browser version support in previous releases didn't reflect the actual feature set used in the editor.

`array.prototype.at()` was introduced 1.5 years ago, but Safari started support with 15.4.
