### PR TITLE
Replace Editor proxy URL with server URL

### DIFF
--- a/content/guides/setup/import-legacy-system-documents.md
+++ b/content/guides/setup/import-legacy-system-documents.md
@@ -44,9 +44,8 @@ Example curl request to import a document with a custom document id:
 
 ```js
 curl -k -X POST "https://server.livingdocs.io/api/v1/import/documents" \
-  -H 'Accept: application/json' \
-  -H 'Authorization: Bearer ey1234' \
-  -H 'Content-Type: application/json; charset=utf-8' \
+  -H "Authorization: Bearer ey1234" \
+  -H "Content-Type: application/json; charset=utf-8" \
   --data-binary @- << EOF
  {
   // Attention! It's important that the systemName is always the same

--- a/content/guides/setup/import-legacy-system-documents.md
+++ b/content/guides/setup/import-legacy-system-documents.md
@@ -43,7 +43,7 @@ documents: {
 Example curl request to import a document with a custom document id:
 
 ```js
-curl -k -X POST "https://edit.livingdocs.io/proxy/api/v1/import/documents" \
+curl -k -X POST "https://server.livingdocs.io/api/v1/import/documents" \
   -H 'Accept: application/json' \
   -H 'Authorization: Bearer ey1234' \
   -H 'Content-Type: application/json; charset=utf-8' \

--- a/content/reference/public-api/add-delivery-status.md
+++ b/content/reference/public-api/add-delivery-status.md
@@ -17,7 +17,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X POST "https://edit.livingdocs.io/proxy/api/api/v1/documents/:documentId/addDeliveryStatus" \
+curl -k -X POST "https://server.livingdocs.io/api/v1/documents/:documentId/addDeliveryStatus" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H 'Content-Type: application/json; charset=utf-8' \

--- a/content/reference/public-api/add-delivery-status.md
+++ b/content/reference/public-api/add-delivery-status.md
@@ -18,9 +18,8 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X POST "https://server.livingdocs.io/api/v1/documents/:documentId/addDeliveryStatus" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
-  -H 'Content-Type: application/json; charset=utf-8' \
+  -H "Content-Type: application/json; charset=utf-8" \
   --data-binary @- << EOF
   {
     "reportId": "2SG2MAA9RwPn",

--- a/content/reference/public-api/composition-api.md
+++ b/content/reference/public-api/composition-api.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X POST "https://edit.livingdocs.io/proxy/api/api/beta/composition/:documentId" \
+curl -k -X POST "https://server.livingdocs.io/api/beta/composition/:documentId" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H 'Content-Type: application/json; charset=utf-8' \

--- a/content/reference/public-api/composition-api.md
+++ b/content/reference/public-api/composition-api.md
@@ -17,9 +17,8 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X POST "https://server.livingdocs.io/api/beta/composition/:documentId" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
-  -H 'Content-Type: application/json; charset=utf-8' \
+  -H "Content-Type: application/json; charset=utf-8" \
   --data-binary @- << EOF
  {
     "fields": ["systemdata", "content", "metadata", "includes", "html"]

--- a/content/reference/public-api/document-categories.md
+++ b/content/reference/public-api/document-categories.md
@@ -17,7 +17,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/categories/:categoryId" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
@@ -92,7 +91,6 @@ api/v1/categories/123abc?inheritMetadata=true
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/categories" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/document-categories.md
+++ b/content/reference/public-api/document-categories.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/categories/:categoryId" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/categories/:categoryId" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
@@ -91,7 +91,7 @@ api/v1/categories/123abc?inheritMetadata=true
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/categories" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/categories" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/document-command-api.md
+++ b/content/reference/public-api/document-command-api.md
@@ -18,9 +18,14 @@ scopes="public-api:write"
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X PATCH "https://edit.livingdocs.io/proxy/api/api/v1/documents/:id/commands" \
-  -H "Accept: application/json" \
-  -H "Authorization: Bearer $ACCESS_TOKEN"
+curl -k -X PATCH "https://server.livingdocs.io/api/v1/documents/:id/commands" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $ACCESS_TOKEN" \
+  --data-binary @- << EOF
+  {
+    "commands": [{"operation": "setMetadataProperty", "propertyName": "title", "value": "updated title"}]
+  }
+EOF
 ```
 
 --endpoint--

--- a/content/reference/public-api/document-lists.md
+++ b/content/reference/public-api/document-lists.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/document-lists/:id?reverse=false&limit=20" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/document-lists/:id?reverse=false&limit=20" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
@@ -98,7 +98,7 @@ api/v1/document-lists/1
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/document-lists" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/document-lists" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/document-lists.md
+++ b/content/reference/public-api/document-lists.md
@@ -17,7 +17,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/document-lists/:id?reverse=false&limit=20" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
@@ -99,7 +98,6 @@ api/v1/document-lists/1
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/document-lists" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/drafts/incoming-references.md
+++ b/content/reference/public-api/drafts/incoming-references.md
@@ -18,7 +18,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/drafts/:documentId/incomingDocumentReferences" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/drafts/incoming-references.md
+++ b/content/reference/public-api/drafts/incoming-references.md
@@ -17,7 +17,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/drafts/:documentId/incomingDocumentReferences" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/drafts/:documentId/incomingDocumentReferences" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/drafts/latest-draft-beta.md
+++ b/content/reference/public-api/drafts/latest-draft-beta.md
@@ -18,7 +18,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/beta/documents/:documentId/latestDraft" \
+curl -k -X GET "https://server.livingdocs.io/api/beta/documents/:documentId/latestDraft" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/drafts/latest-draft-beta.md
+++ b/content/reference/public-api/drafts/latest-draft-beta.md
@@ -19,7 +19,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/beta/documents/:documentId/latestDraft" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/get-started.md
+++ b/content/reference/public-api/get-started.md
@@ -21,7 +21,6 @@ Embed the `AccessToken` in the header of every HTTP request as shown below.
 ### Request HTTP headers
 
 ```
-Accept: application/json
 Authorization: Bearer ey1234
 ```
 
@@ -30,7 +29,6 @@ Authorization: Bearer ey1234
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "http://localhost:9090/api/v1/project"
-  -H "Accept: application/json"
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
@@ -137,8 +135,8 @@ Don't forget to replace [your token.](https://edit.livingdocs.io/access/111/publ
 --query--
 
 ```bash
-curl -H 'Authorization: Bearer your_token' \
-https://server.livingdocs.io/api/v1/documents/latestPublications
+curl -k -X GET https://server.livingdocs.io/api/v1/documents/latestPublications \
+  -H "Authorization: Bearer your_token"
 ```
 
 --endpoint--

--- a/content/reference/public-api/health.md
+++ b/content/reference/public-api/health.md
@@ -14,8 +14,7 @@ menus:
 --query--
 
 ```bash
-curl -k -X GET "https://server.livingdocs.io/api/v1/health" \
-  -H "Accept: application/json"
+curl -k -X GET "https://server.livingdocs.io/api/v1/health"
 ```
 
 --endpoint--

--- a/content/reference/public-api/health.md
+++ b/content/reference/public-api/health.md
@@ -14,7 +14,7 @@ menus:
 --query--
 
 ```bash
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/health" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/health" \
   -H "Accept: application/json"
 ```
 

--- a/content/reference/public-api/imports/documents.md
+++ b/content/reference/public-api/imports/documents.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X POST "https://edit.livingdocs.io/proxy/api/api/v1/import/documents" \
+curl -k -X POST "https://server.livingdocs.io/api/v1/import/documents" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H 'Content-Type: application/json; charset=utf-8' \
@@ -140,7 +140,7 @@ api/v1/import/documents
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/import/documents/status" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/import/documents/status" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/imports/documents.md
+++ b/content/reference/public-api/imports/documents.md
@@ -17,9 +17,8 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X POST "https://server.livingdocs.io/api/v1/import/documents" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
-  -H 'Content-Type: application/json; charset=utf-8' \
+  -H "Content-Type: application/json; charset=utf-8" \
   --data-binary @- << EOF
   {
     "systemName": "identifier-for-your-system",
@@ -141,7 +140,6 @@ api/v1/import/documents
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/import/documents/status" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/imports/images.md
+++ b/content/reference/public-api/imports/images.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X POST "https://edit.livingdocs.io/proxy/api/api/v1/import/images" \
+curl -k -X POST "https://server.livingdocs.io/api/v1/import/images" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H 'Content-Type: application/json; charset=utf-8' \
@@ -123,7 +123,7 @@ api/v1/import/images
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/import/images/status" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/import/images/status" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/imports/images.md
+++ b/content/reference/public-api/imports/images.md
@@ -17,9 +17,8 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X POST "https://server.livingdocs.io/api/v1/import/images" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
-  -H 'Content-Type: application/json; charset=utf-8' \
+  -H "Content-Type: application/json; charset=utf-8" \
   --data-binary @- << EOF
   {
     "systemName": "identifier-for-your-system",
@@ -124,7 +123,6 @@ api/v1/import/images
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/import/images/status" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/imports/media-library-entries.md
+++ b/content/reference/public-api/imports/media-library-entries.md
@@ -17,9 +17,8 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X POST "https://server.livingdocs.io/api/v1/import/mediaLibrary" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
-  -H 'Content-Type: application/json; charset=utf-8' \
+  -H "Content-Type: application/json; charset=utf-8" \
   --data-binary @- << EOF
   {
     "mediaLibraryEntries": []

--- a/content/reference/public-api/imports/media-library-entries.md
+++ b/content/reference/public-api/imports/media-library-entries.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X POST "https://edit.livingdocs.io/proxy/api/api/v1/import/mediaLibrary" \
+curl -k -X POST "https://server.livingdocs.io/api/v1/import/mediaLibrary" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H 'Content-Type: application/json; charset=utf-8' \

--- a/content/reference/public-api/imports/videos.md
+++ b/content/reference/public-api/imports/videos.md
@@ -17,9 +17,8 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X POST "https://server.livingdocs.io/api/v1/import/videos" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
-  -H 'Content-Type: application/json; charset=utf-8' \
+  -H "Content-Type: application/json; charset=utf-8" \
   --data-binary @- << EOF
   {
     "systemName": "identifier-for-your-system",

--- a/content/reference/public-api/imports/videos.md
+++ b/content/reference/public-api/imports/videos.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X POST "https://edit.livingdocs.io/proxy/api/api/v1/import/videos" \
+curl -k -X POST "https://server.livingdocs.io/api/v1/import/videos" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H 'Content-Type: application/json; charset=utf-8' \

--- a/content/reference/public-api/media-library.md
+++ b/content/reference/public-api/media-library.md
@@ -286,7 +286,6 @@ api/v1/mediaLibrary?externalId=ex-1&systemName=externalSystem
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/mediaLibrary/:mediaId/incomingDocumentReferences" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
@@ -369,7 +368,6 @@ This endpoint returns all publications which link to this Media Library Entry (v
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/mediaLibrary/:mediaId/incomingMediaReferences" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/media-library.md
+++ b/content/reference/public-api/media-library.md
@@ -60,8 +60,8 @@ api/v1/mediaLibrary/:id
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X PATCH "https://edit.livingdocs.io/proxy/api/api/v1/mediaLibrary/:id" \
-  -H "Accept: application/json" \
+curl -k -X PATCH "https://server.livingdocs.io/api/v1/mediaLibrary/:id" \
+  -H "Content-Type: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
@@ -285,7 +285,7 @@ api/v1/mediaLibrary?externalId=ex-1&systemName=externalSystem
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/mediaLibrary/:mediaId/incomingDocumentReferences" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/mediaLibrary/:mediaId/incomingDocumentReferences" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
@@ -368,7 +368,7 @@ This endpoint returns all publications which link to this Media Library Entry (v
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/mediaLibrary/:mediaId/incomingMediaReferences" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/mediaLibrary/:mediaId/incomingMediaReferences" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/menus.md
+++ b/content/reference/public-api/menus.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/menus/:channelHandle" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/menus/:channelHandle" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/menus.md
+++ b/content/reference/public-api/menus.md
@@ -17,7 +17,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/menus/:channelHandle" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/project.md
+++ b/content/reference/public-api/project.md
@@ -17,7 +17,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/projectConfig" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
@@ -432,7 +431,6 @@ This endpoint returns the [Project Config]({{< ref "/reference/project-config" >
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/project" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
@@ -539,7 +537,6 @@ Deprecated: Use `GET api/v1/projectConfig` instead.
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/channels/:channelHandle" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
@@ -641,7 +638,6 @@ Deprecated: Use `GET api/v1/projectConfig` instead.
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/design/:designVersion" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/project.md
+++ b/content/reference/public-api/project.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/projectConfig" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/projectConfig" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
@@ -431,7 +431,7 @@ This endpoint returns the [Project Config]({{< ref "/reference/project-config" >
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/project" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/project" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
@@ -538,7 +538,7 @@ Deprecated: Use `GET api/v1/projectConfig` instead.
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/channels/:channelHandle" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/channels/:channelHandle" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
@@ -640,7 +640,7 @@ Deprecated: Use `GET api/v1/projectConfig` instead.
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/design/:designVersion" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/design/:designVersion" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/publications/latest-publication-beta.md
+++ b/content/reference/public-api/publications/latest-publication-beta.md
@@ -19,7 +19,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/beta/documents/:documentId/latestPublication" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/publications/latest-publication-beta.md
+++ b/content/reference/public-api/publications/latest-publication-beta.md
@@ -18,7 +18,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/beta/documents/:documentId/latestPublication" \
+curl -k -X GET "https://server.livingdocs.io/api/beta/documents/:documentId/latestPublication" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/publications/latest-publication.md
+++ b/content/reference/public-api/publications/latest-publication.md
@@ -17,7 +17,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/documents/:documentId/latestPublication" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/publications/latest-publication.md
+++ b/content/reference/public-api/publications/latest-publication.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/documents/:documentId/latestPublication" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/documents/:documentId/latestPublication" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/publications/latest-publications-beta.md
+++ b/content/reference/public-api/publications/latest-publications-beta.md
@@ -19,7 +19,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/beta/documents/latestPublications" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/publications/latest-publications-beta.md
+++ b/content/reference/public-api/publications/latest-publications-beta.md
@@ -18,7 +18,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/beta/documents/latestPublications" \
+curl -k -X GET "https://server.livingdocs.io/api/beta/documents/latestPublications" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/publications/latest-publications.md
+++ b/content/reference/public-api/publications/latest-publications.md
@@ -17,7 +17,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/documents/latestPublications" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/publications/latest-publications.md
+++ b/content/reference/public-api/publications/latest-publications.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/documents/latestPublications" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/documents/latestPublications" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/publications/publication-events.md
+++ b/content/reference/public-api/publications/publication-events.md
@@ -17,7 +17,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/publicationEvents" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/publications/publication-events.md
+++ b/content/reference/public-api/publications/publication-events.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/publicationEvents" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/publicationEvents" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/publications/references.md
+++ b/content/reference/public-api/publications/references.md
@@ -17,7 +17,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/documents/:documentId/incomingDocumentReferences" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
@@ -106,7 +105,6 @@ Find publications in a [Document List]({{< ref "/reference/public-api/document-l
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/documents/:documentId/incomingMediaReferences" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/publications/references.md
+++ b/content/reference/public-api/publications/references.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/documents/:documentId/incomingDocumentReferences" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/documents/:documentId/incomingDocumentReferences" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
@@ -105,7 +105,7 @@ Find publications in a [Document List]({{< ref "/reference/public-api/document-l
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/documents/:documentId/incomingMediaReferences" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/documents/:documentId/incomingMediaReferences" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/publications/renditions.md
+++ b/content/reference/public-api/publications/renditions.md
@@ -17,7 +17,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/documents/:documentId/latestPublication/renditions/:renditionHandles" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/publications/renditions.md
+++ b/content/reference/public-api/publications/renditions.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/documents/:documentId/latestPublication/renditions/:renditionHandles" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/documents/:documentId/latestPublication/renditions/:renditionHandles" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/publications/search.md
+++ b/content/reference/public-api/publications/search.md
@@ -15,7 +15,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/publications/search" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/publications/search" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/publications/search.md
+++ b/content/reference/public-api/publications/search.md
@@ -16,7 +16,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/publications/search" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/retresco.md
+++ b/content/reference/public-api/retresco.md
@@ -17,7 +17,7 @@ menus:
 --query--
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X POST "https://edit.livingdocs.io/proxy/api/api/v1/retresco/re-enrich" \
+curl -k -X POST "https://server.livingdocs.io/api/v1/retresco/re-enrich" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   -H 'Content-Type: application/json; charset=utf-8' \

--- a/content/reference/public-api/retresco.md
+++ b/content/reference/public-api/retresco.md
@@ -18,9 +18,8 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X POST "https://server.livingdocs.io/api/v1/retresco/re-enrich" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
-  -H 'Content-Type: application/json; charset=utf-8' \
+  -H "Content-Type: application/json; charset=utf-8" \
   --data-binary @- << EOF
   {
     "doc_ids": ["1", "2", "3"]

--- a/content/reference/public-api/routing.md
+++ b/content/reference/public-api/routing.md
@@ -17,7 +17,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/routing/resolve?path=:path" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 

--- a/content/reference/public-api/routing.md
+++ b/content/reference/public-api/routing.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/routing/resolve?path=:path" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/routing/resolve?path=:path" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/sitemaps.md
+++ b/content/reference/public-api/sitemaps.md
@@ -16,7 +16,7 @@ menus:
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/sitemaps/index?baseUrl=https://livingdocs.io" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/sitemaps/index?baseUrl=https://livingdocs.io" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
@@ -77,7 +77,7 @@ This endoint returns a sitemap index containing links to individual sitemap file
 
 ```bash
 ACCESS_TOKEN=ey1234
-curl -k -X GET "https://edit.livingdocs.io/proxy/api/api/v1/sitemaps/entries?baseUrl=https://livingdocs.io&date=2021-05" \
+curl -k -X GET "https://server.livingdocs.io/api/v1/sitemaps/entries?baseUrl=https://livingdocs.io&date=2021-05" \
   -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```

--- a/content/reference/public-api/sitemaps.md
+++ b/content/reference/public-api/sitemaps.md
@@ -17,7 +17,6 @@ menus:
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/sitemaps/index?baseUrl=https://livingdocs.io" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 
@@ -78,7 +77,6 @@ This endoint returns a sitemap index containing links to individual sitemap file
 ```bash
 ACCESS_TOKEN=ey1234
 curl -k -X GET "https://server.livingdocs.io/api/v1/sitemaps/entries?baseUrl=https://livingdocs.io&date=2021-05" \
-  -H "Accept: application/json" \
   -H "Authorization: Bearer $ACCESS_TOKEN"
 ```
 


### PR DESCRIPTION
Replace `Accept` header with `Content-Type` since requests might be ignored when `Content-Type` header is not defined.