### PR TITLE
Use new liServer.register methods

### DIFF
--- a/content/customising/server-configuration/single-sign-on.md
+++ b/content/customising/server-configuration/single-sign-on.md
@@ -36,7 +36,7 @@ In the following example we set different providers: Azure, Github, Google and F
             return ['owners']
           },
           // User will be created and logged into this project (enterprise use-case)
-          defaultProjectHandle: 'enterprise-web-print' // alternative 'defaultProjectId: 1'
+          defaultProjectHandle: 'daily-planet' // alternative 'defaultProjectId: 1'
         },
         ui: {
           label: 'AD',
@@ -59,7 +59,7 @@ In the following example we set different providers: Azure, Github, Google and F
             return ['owners']
           },
           // User will be created and logged into this project (enterprise use-case)
-          defaultProjectHandle: 'enterprise-web-print' // alternative 'defaultProjectId: 1'
+          defaultProjectHandle: 'daily-planet' // alternative 'defaultProjectId: 1'
         },
         ui: {
           label: 'Google',

--- a/content/customising/server/data-source-api.md
+++ b/content/customising/server/data-source-api.md
@@ -29,11 +29,10 @@ You can register a DataSource (e.g. `labelValuePairDataSource`) and use it as da
 ```js
 const axios = require('axios')
 
-liServer.features.register('data-sources', async function (feature, server) {
-  const dataSourcesApi = server.features.api('li-data-sources')
+liServer.registerInitializedHook(() => {
 
   // register code on the server
-  dataSourcesApi.register({
+  liServer.registerDataSource({
     handle: 'labelValuePairDataSource',
     // result for labelValuePair = [{label, value}, ...]
     dataFormat: 'labelValuePair',

--- a/content/customising/server/server-hooks.md
+++ b/content/customising/server/server-hooks.md
@@ -51,8 +51,8 @@ With publication hooks you can influence the [`Document Publication Lifecycle`](
 
 **Two ways of registering a Publication Hook**
 
-- `registerPublicationHooks`: Register as many hooks as you need, executed in the order they got registered
-- `registerPublicationServerHooks`: Hooks are executed on all projects. These hooks run before project specific ones.
+- `liServer.registerPublicationHooks()`: Register publication hooks per project.
+- `liServer.registerGlobalPublicationHooks()`: Register publication hooks that are executed on all projects (these hooks run before project specific ones).
 
 **API of Publication Hooks**
 
@@ -69,13 +69,14 @@ const appConfig = require('./conf')
 const liServer = require('@livingdocs/server')(appConfig)
 
 liServer.registerInitializedHook(async () => {
-  liServer.features.api('li-documents').registerPublicationServerHooks({
+  // Global publish hooks
+  liServer.registerGlobalPublicationHooks({
     async preparePublishHookAsync ({documentVersion}) { return }
   })
 
-  liServer.features.api('li-documents').registerPublicationHooks({
-    projectHandle: 'your-awesome-project',
-    channelHandle: 'default',
+  // Proejct-specific publish hooks
+  liServer.registerPublicationHooks({
+    projectHandle: 'daily-planet',
     async preparePublishHookAsync ({documentVersion}) { return },
     async postPublishHookAsync ({documentVersion}) {
       liServer.log.info(`postPublishHookAsync called for documentType: ${documentVersion.documentType}!`)
@@ -203,7 +204,7 @@ async postUnpublishHookAsync ({documentVersion}) {
 
 ### Register a List Hook
 
-There is one hook for the `document-lists` feature. The hook can be registered through `registerListHooks()`.
+There is one hook for the `document-lists` feature. The hook can be registered through `liServer.registerListHooks()`.
 
 Example:
 ```js
@@ -211,9 +212,8 @@ const appConfig = require('./conf')
 const liServer = require('@livingdocs/server')(appConfig)
 
 liServer.registerInitializedHook(async () => {
-  liServer.features.api('li-document-lists').registerListHooks({
-    projectHandle: 'your-interesting-project',
-    channelHandle: 'some-channel',
+  liServer.registerListHooks({
+    projectHandle: 'daily-planet',
     listUpdateHookAsync ({projectId, listId, remove, add}) {
       console.info(
         `The list with id '${listId}' in the project '${projectId}' has changes.`,

--- a/content/customising/server/server-hooks.md
+++ b/content/customising/server/server-hooks.md
@@ -74,7 +74,7 @@ liServer.registerInitializedHook(async () => {
     async preparePublishHookAsync ({documentVersion}) { return }
   })
 
-  // Proejct-specific publish hooks
+  // Project-specific publish hooks
   liServer.registerPublicationHooks({
     projectHandle: 'daily-planet',
     async preparePublishHookAsync ({documentVersion}) { return },

--- a/content/guides/authentication/azure-ad-login/index.md
+++ b/content/guides/authentication/azure-ad-login/index.md
@@ -6,7 +6,7 @@ weight: 2
 ---
 
 ## SSO example with Azure AD
-To use SSO with OpenID Connect we have a strategy `li-authentication-openid-connect` to use in the `auth.connections` config. With this strategy, you can use a SSO Service (AzureAD, Google, Facebook, ...) which supports the OpenID Connect for authentication.  
+To use SSO with OpenID Connect we have a strategy `li-authentication-openid-connect` to use in the `auth.connections` config. With this strategy, you can use a SSO Service (AzureAD, Google, Facebook, ...) which supports the OpenID Connect for authentication.
 
 To enable AzureAD SSO for Livingdocs, add the config below to the server config in `auth.connections`. It creates a setup for SSO with AzureAD and shows the button for that on the login page. It is also using the existing user from Livingdocs and create an AzureAD Identity. The already written articles with this user will still be assigned to the same user. The match of the user is done with the email address.
 
@@ -38,7 +38,7 @@ module.exports = {
         issuer: 'https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration',
         config: {
           clientId: azureConfig.clientId,
-          clientSecret: azureConfig.clientSecret, 
+          clientSecret: azureConfig.clientSecret,
           // Check `Configuring OpenID in Azure AD` section for a guide
           scope: 'openid email profile',
           async extractClaims ({tokenSet}) {
@@ -55,7 +55,7 @@ module.exports = {
           async extractProjects ({client, tokenSet, claims}) {
             // return a default
             return [{
-              projectHandle: 'enterprise-web-print',
+              projectHandle: 'daily-planet',
               groupLabels: ['owners', 'editors']
             }, {
               projectHandle: 'service',

--- a/content/guides/documents/includes/oembed/index.md
+++ b/content/guides/documents/includes/oembed/index.md
@@ -52,14 +52,13 @@ For an idea of websites which support oEmbed you can take a look at the oEmbed [
 During server initialization the oEmbed providers used by all projects need to be registered.
 
 ```js
-// runtime-config.js
-liServer.registerInitializedHook(async () => {
-  const oembedProviders = require('./providers')
-  liServer.features.api('li-oembed').registerProviders(oembedProviders)
+// app/server.js
+liServer.registerInitializedHook(() => {
+  liServer.registerOembedProviders(oembedProviders)
 })
 ```
 
-The parameter passed to the `registerProviders()` functions should be an array of provider objects.
+The parameter passed to the `registerOembedProviders()` function must be an array of provider objects.
 
 ```js
 // providers.js

--- a/content/guides/documents/includes/twitter-embed/index.md
+++ b/content/guides/documents/includes/twitter-embed/index.md
@@ -55,17 +55,13 @@ rendering the include with parameters filled in the editor.
 
 ```js
 // app/server.js
-liServer.features.register('custom-includes', require('app/includes'))
-
-// app/includes/index.js
-module.exports = async function (feature, server) {
-  const includesApi = server.features.api('li-includes')
-  await includesApi.registerServices([
-    require('../../plugins/includes/tweet')
+liServer.registerInitializedHook(() => {
+  liServer.registerIncludeServices([
+    require('./include-services/tweet')
   ])
-}
+})
 
-// ../../plugins/includes/tweet.js
+// app/include-services/tweet.js
 const fetch = require('node-fetch')
 module.exports = {
   name: 'twitterInclude',

--- a/content/guides/documents/includes/youtube-embed/index.md
+++ b/content/guides/documents/includes/youtube-embed/index.md
@@ -43,19 +43,13 @@ This service has one main job - rendering the include with parameters filled in 
 
 ```js
 // app/server.js
-liServer.features.register('custom-includes', require('app/includes'))
-
-// app/includes/index.js
-module.exports = async function (feature, server) {
-  const includesApi = server.features.api('li-includes')
-
-  // register the include service
-  await includesApi.registerServices([
-    require('../../plugins/includes/youtubeService')
+liServer.registerInitializedHook(() => {
+  liServer.registerIncludeServices([
+    require('./include-services/youtube-service')
   ])
-}
+})
 
-// ../../plugins/includes/youtubeService.js
+// app/include-services/youtube-service.js
 module.exports = {
   name: 'youtubeIncludeService',
 

--- a/content/guides/editor/document-creation-flow.md
+++ b/content/guides/editor/document-creation-flow.md
@@ -27,7 +27,7 @@ projectConfig.editorSettings = {
   documentCreationFlows: [
     {
       handle: 'breakingNews',
-      // register a createFunction with documentApi.registerCreateFunction (later in the guide)
+      // register a createFunction with liServer.registerCreateFunction() (later in the guide)
       createFunction: 'breakingNews',
       createButtonLabel: 'Create Breaking News',
 
@@ -98,9 +98,7 @@ Let's register the createFunction: `breakingNews`, the one you defined in the da
 
 ```js
 liServer.registerInitializedHook(async () => {
-  const documentApi = liServer.features.api('li-documents').document
-
-  documentApi.registerCreateFunction({
+  liServer.registerCreateFunction({
     handle: 'breakingNews',
 
     // params and context are coming from Document Creation Flow

--- a/content/guides/editor/image-gallery.md
+++ b/content/guides/editor/image-gallery.md
@@ -339,14 +339,12 @@ const galleryIsNotPublishedPlaceholder = dedent`
 ### Register "gallery-teaser" Include
 
 ```js
-// runtime-config.js
-const liServer = Server(require('../conf'))
-liServer.features.register('include-services', async function (feature, server) {
-  const includesApi = server.features.api('li-includes')
-  const publicationApi = server.features.api('li-documents').publication
+// app/server.js
+liServer.registerInitializedHook(() => {
+  const publicationApi = liServer.features.api('li-documents').publication
 
-  await includesApi.registerServices([
-    require('./plugins/includes/gallery-teaser')({publicationApi})
+  liServer.registerIncludeServices([
+    require('./include-services/gallery-teaser')({publicationApi})
   ])
 })
 ```

--- a/content/guides/editor/menu-tool/index.md
+++ b/content/guides/editor/menu-tool/index.md
@@ -1,6 +1,6 @@
 ---
 title: Menu Tool
-description: Use Data-Record and li-tree plugin to build a menu tool 
+description: Use Data-Record and li-tree plugin to build a menu tool
 weight: 4
 ---
 
@@ -36,7 +36,7 @@ Make sure to add it to the projects' list of Content Types.
   info: {
     label: 'Menu'
   },
-  
+
   metadata: [
     {
       handle: 'name',
@@ -126,7 +126,7 @@ Add a Document Creation Flow and a Table Dashboard to your Editor Settings:
 And here the registered creation function:
 
 ```js
-documentApi.registerCreateFunction({
+liServer.registerCreateFunction({
   handle: 'createMenu',
   async create ({params = {}}) {
     return {

--- a/content/guides/integrations/desknet/index.md
+++ b/content/guides/integrations/desknet/index.md
@@ -623,7 +623,7 @@ A user can change the date to see the scheduled articles in the configured platf
 
 Along with manually dragging stories from the side bar on to the page to create teasers, it is also possible to register a document create flow to update or re-generate the content for the current document.
 
-This feature should be considered beta. It is likely that we will refactor this in the future because the `registerCreateFunction` and `create` naming is not ideal for this scenario, where we are actually updating or generating content.
+This feature should be considered beta.
 
 #### Register Create Function
 
@@ -632,7 +632,7 @@ To begin with you should register a new create function in your server runtime c
 ```js
 liServer.registerInitializedHook(async () => {
   const documentApi = liServer.features.api('li-documents').document
-  documentApi.registerCreateFunction({
+  documentApi.registerGenerateFunction({
     handle: 'generateTeasersFromDesknetSchedule',
     async create ({projectConfig, userId, params = {}, context = {}}) {
       // Extract Desk-Net elements from schedule tree

--- a/content/guides/media-library/media-sources/index.md
+++ b/content/guides/media-library/media-sources/index.md
@@ -91,9 +91,11 @@ module.exports = {
 ### Step 2 - Register the Media Source Plugin
 
 ```js
-liServer.registerInitializedHook(async () => {
-  const mediaLibraryApi = liServer.features.api('li-media-library')
-  mediaLibraryApi.registerMediaSource(require('./plugins/media-sources/example_plugin'))
+// app/server.js
+liServer.registerInitializedHook(() => {
+  liServer.registerMediaSources([
+    require('./plugins/media-sources/example_plugin')
+  ])
 })
 ```
 

--- a/content/guides/organisation/sitemaps-and-feeds.md
+++ b/content/guides/organisation/sitemaps-and-feeds.md
@@ -36,13 +36,8 @@ Feeds are highly customizable and no there is no 'one-fits-it-all' solution. We 
 You will need to add your own HTTP-API.
 
 ```js
-// Register the feature
-liServer.features.register('feeds', require('./feeds'))
-```
-
-```js
-// Setup the Feature - ./feeds/index.js
-module.exports = function (feature, server) {
+// /app/server.js
+liServer.registerInitializedHook(function () {
   const searchManager = server.features.api('li-search').searchManager
   const sitemapsApi = server.features.api('li-sitemaps')
 
@@ -51,40 +46,21 @@ module.exports = function (feature, server) {
     sitemapsApi
   })
 
-  const controller = require('./feeds_controller')({feedsApi})
-  const routes = require('./feeds_routes')
+  liServer.registerServerRoutes({
+    title: 'RSS Feeds',
+    description: 'Feed endpoints',
+    method: 'get',
+    prefix: '/daily-planet',
+    path: '/feed',
+    auth: 'public-api:read',
 
-  feature.registerResource({controller, routes})
-}
-```
-
-```js
-// Setup the Feature - ./feeds/feeds_routes.js
-module.exports = {
-  title: 'RSS Feeds',
-  description: 'Feed endpoints',
-  endpoints: [
-    {
-      path: 'custom/api/v1/feed',
-      auth: 'public-api:read',
-      method: 'get',
-      action: 'getFeed'
-    }
-  ]
-}
-```
-
-```js
-// Setup the Feature - ./feeds/feeds_controller.js
-module.exports = ({feedsApi}) => {
-  return {
-    async getFeed (req, res) {
+    async action (req, res) {
       const {channelId, projectId} = req.verifiedToken
       const feed = await feedsApi.getFeed({channelId, projectId})
       return res.success(feed)
     }
-  }
-}
+  })
+})
 ```
 
 ```js

--- a/content/operations/releases/old/release-2017-12.md
+++ b/content/operations/releases/old/release-2017-12.md
@@ -72,7 +72,7 @@ The behaviour of `registerPublicationHooks` changes. It allows registering a pub
 
 ```javascript
 liServer.features.api('li-documents').registerPublicationHooks({
-  projectHandle: 'your-awesome-project',
+  projectHandle: 'daily-planet',
   channelHandle: 'some-channel',
   prepublishHook (documentVersion, callback) { callback(null, documentVersion) },
   publishHook ({documentType, payload}, callback) { callback() },
@@ -84,7 +84,7 @@ liServer.features.api('li-documents').registerPublicationHooks({
 
 ```diff
  liServer.features.api('li-documents').registerPublicationHooks({
-   projectHandle: 'your-awesome-project',
+   projectHandle: 'daily-planet',
    channelHandle: 'some-channel',
 +  prepublishHook (documentVersion, callback) { callback(null, documentVersion) },
    publishHook ({documentType, payload}, callback) { callback() },

--- a/content/reference/document/includes/server-customization.md
+++ b/content/reference/document/includes/server-customization.md
@@ -13,14 +13,13 @@ We recommend where possible going down the paramsSchema route for includes. This
 ## Registering your include
 
 ```js
-// runtime config
-liServer.features.register('include-services', async function (feature, server) {
-  const includesApi = liServer.features.api('li-includes')
-  await includesApi.registerServices([
+// app/server.js
+liServer.registerInitializedHook(() => {
+  liServer.registerIncludeServices([
     // registers the include rendering service
-    require('./plugins/includes/teaser.js')
+    require('./include-services/teaser.js')
   ])
-}
+})
 ```
 
 
@@ -392,4 +391,4 @@ Passes any value to the render function.
 config: {
   foo: 'bar'
 }
-``
+```

--- a/content/reference/project-config/editor-settings.md
+++ b/content/reference/project-config/editor-settings.md
@@ -618,7 +618,7 @@ componentOptions: {
   showContentType: true,
   // Only works if no displayTitlePattern is configured on the contentType
   allowTitleEdit: true
-  
+
 }
 ```
 
@@ -748,7 +748,7 @@ Check that [guide]({{< ref "/guides/editor/document-creation-flow" >}}) for more
 documentCreationFlows: [
   {
     handle: 'breakingNews',
-    // register a createFunction with documentApi.registerCreateFunction
+    // register a createFunction with liServer.registerCreateFunction()
     // default createFunction handle: 'liDefaultCreationFunction'
     createFunction: 'breakingNews',
     createButtonLabel: 'Create Breaking News',


### PR DESCRIPTION
# Changelog

- 🎁 Use new `liServer.register...()` methods everywhere.
- 🎁 Replace `liServer.features.register()` with `liServer.registerServerRoutes()`
- 🔧 Use `daily-planet` as example project handle