### PR TITLE
Remove rendition doc

### DIFF
--- a/content/reference/document/includes/introduction.md
+++ b/content/reference/document/includes/introduction.md
@@ -119,25 +119,3 @@ If the include is resolved instead of the `<ld-include>` you see the actual HTML
   </a>
 </div>
 ```
-
-### How to configure the rendering option
-
-Includes are not resolved by default. Enable it in the [project configuration]({{< ref "/reference/project-config" >}}):
-
-```js
-module.exports = {
-
-  renditions: {
-    'web': {
-      output: {
-        'html': {
-          outputRenderer: new CheerioHtml(),
-          resolveIncludes: ['embed-teaser']
-        }
-      }
-    }
-  }
-}
-```
-
-The `resolveIncludes` array lists all includes that should be resolved inside of Livingdocs. You can configure this by channel and by rendition.

--- a/content/reference/project-config/content-types.md
+++ b/content/reference/project-config/content-types.md
@@ -95,9 +95,6 @@ contentTypes: [
       }
     ],
 
-    // You'll find the renditions example further below
-    renditions: require.resolve('./path/to/rendition/config'),
-
     // Configuration for the Editor behaviour
     editor: {
       ui: {
@@ -486,41 +483,6 @@ Apart from the general settings (`renderSettings`) you define an entry for each 
 
 See our [Desk-Net plugin guide]({{< ref "/guides/integrations/desknet" >}}) for comprehensive infos (custom code parts require enterprise version).
 
-## Renditions
-
-Renditions can only be changed in the enterprise model since they require custom code.
-
-Example `./path/to/rendition/config`:
-
-```js
-const CheerioHtml = require('../../../lib/render-pipeline/output/cheerio_html')
-
-module.exports = {
-  // a label
-  'web': {
-    output: {
-      // an output renderer
-      'html': {
-        outputRenderer: new CheerioHtml({
-          // middlewares for content alterations
-          middleware: [
-            addSocialLinks,
-            addPublicationDate
-          ]
-        }),
-        // resolve definitions for includes
-        resolveIncludes: ['embed-teaser', 'list', 'categoryList']
-      }
-    }
-  },
-  'app': {
-    output: {
-      'json': appRenderer
-    }
-  }
-}
-```
-
 ## Enable Push Notifications for a ContentType
 
 To enable push notifications for a specific content type you must have a metadata field called `pushNotifications`. Name and plugin must match exactly.
@@ -783,5 +745,3 @@ editor: {
   }
 }
 ```
-
-


### PR DESCRIPTION
# Motivation

Because we don't want customers to use renditions anymore, I removed the doc. I kept the renditions doc in the public API, because the API still supports that requests.