### PR TITLE
Update docs about downstream plugin contexts

### DIFF
--- a/content/operations/releases/release-2023-11.md
+++ b/content/operations/releases/release-2023-11.md
@@ -160,13 +160,14 @@ Plugins used in other contexts than the ones stated in the [docs](https://docs.l
 
 All downstream plugins are supported by default in document metadata and media library metadata. But if a downstream plugin is used in include services, creation flows or push messages, that will cause an error during startup.
 
-If a downstream plugin is being used in an include service params schema the following configuration needs to be added to the plugin declaration:
+If a downstream plugin is being used in an include service or creation flow params schema the following configuration needs to be added to the plugin declaration:
 
 ```
 supportedPluginContexts: [
   'documentMetadata',
   'mediaLibraryEntryMetadata', 
-  'includeParams'
+  'includeParams',
+  'creationFlowParams'
 ]
 ```
 


### PR DESCRIPTION
Now it's also allowed to have custom downstream plugins in creation flow params.