### PR TITLE
Remove unsupported example calling `initializeOembedMetadataExtractor()` in editor customizations

### DIFF
--- a/content/guides/setup/editor-customization.md
+++ b/content/guides/setup/editor-customization.md
@@ -71,10 +71,6 @@ liEditor.metadataServices
 //   Pinterest
 // ]
 
-const Iframely = require('@livingdocs/editor/app/scripts/modules/iframely')
-const defaultExtractor = require('@livingdocs/editor/app/scripts/modules/iframely/default_metadata_extractor')
-Iframely.initializeOembedMetadataExtractor(defaultExtractor)
-
 // Example of changing the date locale
 // moment = require('moment')
 // momentDe = require('moment/locale/de')


### PR DESCRIPTION
Relations:
- Related PRs: https://github.com/livingdocsIO/livingdocs-editor/pull/8074