### PR TITLE
Extend documentation on webhook conditions and change filters

### DIFF
--- a/content/reference/document/metadata/plugins/li-boolean.md
+++ b/content/reference/document/metadata/plugins/li-boolean.md
@@ -16,6 +16,7 @@ support:
   searchIndexing: true
   systemMetadata: false
   planningSystem: false
+  webhookConditions: true
 description: |
   A simple Boolean value store, represented in the UI with a checkbox which you can toggle on/off.
 

--- a/content/reference/document/metadata/plugins/li-color.md
+++ b/content/reference/document/metadata/plugins/li-color.md
@@ -16,6 +16,7 @@ support:
   searchIndexing: true
   systemMetadata: false
   planningSystem: false
+  webhookConditions: true
 description: |
   li-color will provide you with 2 settings (based on `useInputTypeColor`)
   * `useInputTypeColor: true` - color picker which stores the HEX color code

--- a/content/reference/document/metadata/plugins/li-date.md
+++ b/content/reference/document/metadata/plugins/li-date.md
@@ -16,6 +16,7 @@ support:
   searchIndexing: true
   systemMetadata: false
   planningSystem: false
+  webhookConditions: true
 defaultUI: Date input field
 storageFormat: <ISO8601 String>
 contentTypeConfig: |2

--- a/content/reference/document/metadata/plugins/li-datetime.md
+++ b/content/reference/document/metadata/plugins/li-datetime.md
@@ -16,6 +16,7 @@ support:
   searchIndexing: true
   systemMetadata: false
   planningSystem: false
+  webhookConditions: true
 defaultUI: A datetime input
 storageFormat: <ISO8601 String>
 contentTypeConfig: |2

--- a/content/reference/document/metadata/plugins/li-enum.md
+++ b/content/reference/document/metadata/plugins/li-enum.md
@@ -16,6 +16,7 @@ support:
   searchIndexing: true
   systemMetadata: false
   planningSystem: false
+  webhookConditions: true
 description: |
   A `li-enum` metadata field shows a select form based on a statically defined list. On publish the selected value gets validated against the defined static list. With that you can assure that only specific values gets published.
 

--- a/content/reference/document/metadata/plugins/li-external-id.md
+++ b/content/reference/document/metadata/plugins/li-external-id.md
@@ -16,6 +16,7 @@ support:
   searchIndexing: true
   systemMetadata: false
   planningSystem: false
+  webhookConditions: true
 description: |
   A `li-external-id` metadata field can be used to save an external id of another system. For example if you want to have an article reference to your original system. At the moment `li-external-id` by default renders a text area in the UI. If you want to hide it add the config object with `hideFromForm: true`
 defaultUI: Text input

--- a/content/reference/document/metadata/plugins/li-integer.md
+++ b/content/reference/document/metadata/plugins/li-integer.md
@@ -15,6 +15,7 @@ support:
   searchIndexing: true
   systemMetadata: false
   planningSystem: false
+  webhookConditions: true
 defaultUI: |
   * Renders a number input.
   * No UI is rendered if the `handle` is `lastProofreadRevision`.

--- a/content/reference/document/metadata/plugins/li-moderated-collab.md
+++ b/content/reference/document/metadata/plugins/li-moderated-collab.md
@@ -15,6 +15,7 @@ support:
   searchIndexing: false
   systemMetadata: true
   planningSystem: false
+  webhookConditions: true
 description: No longer supported.
 defaultUI: None
 storageFormat: <Boolean>

--- a/content/reference/document/metadata/plugins/li-publish-date.md
+++ b/content/reference/document/metadata/plugins/li-publish-date.md
@@ -16,6 +16,7 @@ support:
   searchIndexing: true
   systemMetadata: false
   planningSystem: false
+  webhookConditions: true
 description: |
   Holds the first publication date, which is user editable.
 

--- a/content/reference/document/metadata/plugins/li-text.md
+++ b/content/reference/document/metadata/plugins/li-text.md
@@ -16,6 +16,7 @@ support:
   searchIndexing: true
   systemMetadata: false
   planningSystem: false
+  webhookConditions: true
 description: |
   A simple text value store.
 

--- a/themes/hugo-docs/layouts/metadata-plugins/single.html
+++ b/themes/hugo-docs/layouts/metadata-plugins/single.html
@@ -53,6 +53,10 @@
             <td>System Metadata</td>
             <td style="text-align: center;">{{ partial "check-cross" .Params.support.systemMetadata }}</td>
           </tr>
+          <tr>
+            <td>Webhook Conditions</td>
+            <td style="text-align: center;">{{ partial "check-cross" .Params.support.webhookConditions }}</td>
+          </tr>
         </table>
 
         {{ if .Params.description }}


### PR DESCRIPTION
Related PRs:
- https://github.com/livingdocsIO/livingdocs-server/pull/6461
- https://github.com/livingdocsIO/livingdocs-server/pull/6499
- https://github.com/livingdocsIO/livingdocs-server/pull/6648
- https://github.com/livingdocsIO/livingdocs-server/pull/3359

## Changelog

- Extends the documentation on webhook conditions and change filters.
- Adds an indicator to metadata plugin pages to show which ones support metadata property conditions.