### PR TITLE
fix(image url building in deliveries): added

### DIFF
--- a/content/operations/releases/release-2024-03.md
+++ b/content/operations/releases/release-2024-03.md
@@ -158,7 +158,7 @@ The metadata plugin schemas are more strict. The server will throw an error for 
 Remove the default `uiSchema` for metadata properties of the media library.
 The schema below was defined as default.
 Plugins now need to list their properties explicitly if they need any of the properties in the config.
-  
+
 ```js
 uiSchema: ms.obj({
   component: 'string',
@@ -207,7 +207,7 @@ The `isDefault` property for named crops is deprecated in both `li-image` and `l
 
 In the release notes for `release-2024-01`, we announced that the behavior for `defaultComponents` in nested containers is going to have a breaking change.
 
-*After some considerations, we decided not to introduce this breaking change.* Nested containers in document content will not inherit the configuration of parent containers. 
+*After some considerations, we decided not to introduce this breaking change.* Nested containers in document content will not inherit the configuration of parent containers.
 
 Default components are looked up in the direct parent container. If no config for the given type was found, it looks for a config in the documents' Content Type (new in `release-2024-03`) and then in the design config. It will *not* look into the configurations of parent containers.
 
@@ -373,6 +373,9 @@ Image urls also get patched at the following locations:
   - `li-image` and `li-poster-image` metadata plugins (also on include params sub-property values)
   - The `params` object of `doc-include` directives
   - Any other object that has an `originalUrl` and `mimeType` attribute. If you have custom attributes using those attributes, please let us know.
+
+If you want to read more on how to compute URLs in the delivery read our guide [here]({{< ref "/guides/media-library/image-services.md#delivery" >}})
+
 
 Watch out:
 - ⚠️ When you've configured a `storage.computeKey` function, a `storage.extractKey` config is now also required that can extract an asset `key` attribute from an url. If the functions do not result in the same key, the process does not start.


### PR DESCRIPTION
A guide to building the URL in deliveries after our changes in the March release. 

I also added a link in the march release. 