### PR TITLE
docs(defaultComponents): remove audio and html component types

### DIFF
--- a/content/operations/releases/release-2024-03.md
+++ b/content/operations/releases/release-2024-03.md
@@ -456,9 +456,7 @@ contentTypes: [
     defaultComponents: {
       paragraph: 'p',
       image: 'img',
-      video: 'video',
-      audio: 'audio',
-      html: 'html'
+      video: 'video'
     }
   }
 ]

--- a/content/reference/project-config/content-types.md
+++ b/content/reference/project-config/content-types.md
@@ -37,9 +37,7 @@ contentTypes: [
     defaultComponents: {
       paragraph: 'p',
       image: 'img',
-      video: 'video',
-      audio: 'audio',
-      html: 'html'
+      video: 'video'
     },
     defaultContent: [
       {component: 'title', position: 'fixed'}


### PR DESCRIPTION
I don't think we support audio and html component types here, at least I have not found any other references in the documentation and at a first glance also no explict handling in the code