### PR TITLE
Fix invalid references after hugo update

### DIFF
--- a/content/customising/advanced/editor-configuration/base-filter.md
+++ b/content/customising/advanced/editor-configuration/base-filter.md
@@ -24,7 +24,7 @@ At all these places, one can use the same query format, e.g.
 {key: 'contentType', term: 'regular'}
 ```
 
-Learn more about the filter queries format [here]({{< ref "/content/reference/public-api/publications/search.md" >}})
+Learn more about the filter queries format [here]({{< ref "/reference/public-api/publications/search.md" >}})
 
 ## Filter Query Examples
 

--- a/content/guides/editor/custom-dashboard-filters/index.md
+++ b/content/guides/editor/custom-dashboard-filters/index.md
@@ -15,7 +15,7 @@ At the moment there are 2 types of custom filters
 - [Custom Vue Component Filter](#custom-vue-component-filter)
   - [Example](#example)
 
-Hint: If you want to create a filter with metadata, make sure they are setup correctly in the ElasticSearch index, using `config: {index: true}` on the [metadata property defined in the content type config]({{< ref "/content/guides/search/publication-index.md">}}).
+Hint: If you want to create a filter with metadata, make sure they are setup correctly in the ElasticSearch index, using `config: {index: true}` on the [metadata property defined in the content type config]({{< ref "/guides/search/publication-index.md" >}}).
 
 
 ## Custom List v2 Filter

--- a/content/guides/editor/multi-language-content/index.md
+++ b/content/guides/editor/multi-language-content/index.md
@@ -111,7 +111,7 @@ In order for the dashboard to have the required metadata, you will need to confi
 }
 ```
 
-Note: if you did your [own dashboard item]({{< ref "../push-notifications#add-a-custom-dashboard-item" >}}), the language column will not work out-of-the-box and you will need to customize your dashboard item to show the language
+Note: if you did your [own dashboard item]({{< ref "/guides/editor/push-notifications#add-a-custom-dashboard-item" >}}), the language column will not work out-of-the-box and you will need to customize your dashboard item to show the language
 
 ## Editor
 

--- a/content/guides/integrations/li2xliff/index.md
+++ b/content/guides/integrations/li2xliff/index.md
@@ -70,9 +70,9 @@ It returns the translated content and, if there are any, an array of errors.
 
 ## Registering Translation Function
 
-To enable the functionality in Livingdocs you will need to activate multiple languages and translations. The documentation can be found [here]({{< ref "/content/reference/project-config/settings.md#languages--translations" >}})
+To enable the functionality in Livingdocs you will need to activate multiple languages and translations. The documentation can be found [here]({{< ref "/reference/project-config/settings.md#languages--translations" >}})
 
-In your Livingdocs Server instance you can subscribe to [server events]({{< ref "/content/customising/advanced/server-events.md" >}}) such as document creation. Then you can send your Livingdoc content for translation.
+In your Livingdocs Server instance you can subscribe to [server events]({{< ref "/customising/advanced/server-events.md" >}}) such as document creation. Then you can send your Livingdoc content for translation.
 
 Here we have an example function:
 
@@ -100,7 +100,7 @@ function registerTranslationHooks ({liServer, config}) {
 }
 ```
 
-And to add the translation function to the server use an [initialized hook]({{< ref "/content/customising/server/server-initalization.md" >}}):
+And to add the translation function to the server use an [initialized hook]({{< ref "/customising/server/server-initalization.md" >}}):
 
 ```js
 register: function ({liServer}) {

--- a/content/operations/releases/release-2022-03.md
+++ b/content/operations/releases/release-2022-03.md
@@ -323,7 +323,7 @@ We removed Callback support in several server API's as we noticed many bugs orig
 
 - 🔥 remove callback support for projectApi (`server.features.api('li-projects')`) functions. Only promise based calls are supported
 
-You can find migration a migration example [here]({{< ref "/content/operations/releases/release-2021-09.md#example-how-to-migrate" >}}).
+You can find migration a migration example [here]({{< ref "/operations/releases/release-2021-09.md#example-how-to-migrate" >}}).
 
 References: [Server PR](https://github.com/livingdocsIO/livingdocs-server/pull/4160)
 

--- a/content/operations/releases/release-2023-07.md
+++ b/content/operations/releases/release-2023-07.md
@@ -129,7 +129,7 @@ The preferred update path would be to use `filters` from the new [Search DSL](#s
 
 ### Removal `liImageProxy` feature
 
-🔥 Features wasn't in use an didn't cover any use case. If you were still using it, you should use imgix or another Image Service provider instead. [More information]({{<ref "/content/guides/media-library/image-services.md">}}).
+🔥 Features wasn't in use an didn't cover any use case. If you were still using it, you should use imgix or another Image Service provider instead. [More information]({{< ref "/guides/media-library/image-services.md" >}}).
 
 * [Remove `liImageProxy` feature](https://github.com/livingdocsIO/livingdocs-server/pull/5772)
 
@@ -148,7 +148,7 @@ Preview API is deprecated and removed with `release-2023-09`: `previewApi.regist
 
 ### Add Api endpoint for incoming references for drafts
 
-New draft endpoint for incoming document references: `/drafts/:documentId/incomingDocumentReferences`. Needs `public-api:drafts:read privileges`. [Learn more]({{<ref "/content/reference/public-api/drafts/incoming-references.md">}})
+New draft endpoint for incoming document references: `/drafts/:documentId/incomingDocumentReferences`. Needs `public-api:drafts:read privileges`. [Learn more]({{< ref "/reference/public-api/drafts/incoming-references.md" >}})
 
 ### Public API Search Filters
 
@@ -348,7 +348,7 @@ metadata: [
 
 ### UI and label config multi-language support
 
-With this release, we introduced multi-language support for the UI and label config. Currently we support English and German as UI languages: [Learn more]({{< ref "/content/guides/editor/multi-language-ui/index.md" >}})
+With this release, we introduced multi-language support for the UI and label config. Currently we support English and German as UI languages: [Learn more]({{< ref "/guides/editor/multi-language-ui/index.md" >}})
 
 Set UI language in editor config:
 
@@ -377,7 +377,7 @@ metadata: [
 
 ### Support significantPublicationDate on document import
 
-Property `significantPublicationDate` sets a date which deliveries can display to viewers: [Learn more]({{< ref "/content/reference/public-api/imports/documents.md" >}})
+Property `significantPublicationDate` sets a date which deliveries can display to viewers: [Learn more]({{< ref "/reference/public-api/imports/documents.md" >}})
 
 When performing a `POST api/v1/import/documents` request, you can define `significantPublicationDate` within `documents.[].publishControl` object. See example below:
 

--- a/content/reference/project-config/settings.md
+++ b/content/reference/project-config/settings.md
@@ -276,7 +276,7 @@ Livingdocs allows you to define documents in multiple languages as well as integ
 
 If you activate the translation feature, then the `language` metadata plugin on a document will contain a `groupId`. You can use this in the `languageGroupId` parameter of the [Public API - Search Publications]({{< ref "/reference/public-api/publications/search" >}}) call to retrieve all translations of a document.
 
-If you want to use a computer assisted translation (CAT) tool to translate livingdocs content you can install our li2xliff library to convert documents to XLIFF for translation and list to [server events]({{< ref "/content/customising/advanced/server-events.md" >}}) to update content. You can follow our in-depth guide [here]({{< ref "/content/guides/integrations/li2xliff/index.md" >}})
+If you want to use a computer assisted translation (CAT) tool to translate livingdocs content you can install our li2xliff library to convert documents to XLIFF for translation and list to [server events]({{< ref "/customising/advanced/server-events.md" >}}) to update content. You can follow our in-depth guide [here]({{< ref "/guides/integrations/li2xliff/index.md" >}})
 
 
 ## Integrations


### PR DESCRIPTION
After updating to Hugo v0.123.x or v0.124.x, the documentation can no longer be built due to invalid references. The reason for this is that some references were prefixed with `/content`. However, they should treat `/content` as their root directory and start paths from there.

Currently, this is not a problem as our CI runs on v0.122.x. But it will come up once we update (or when running a different version locally).