### PR TITLE
Add vulnerability information for the latest 3 releases

### DIFF
--- a/content/operations/releases/release-2023-11.md
+++ b/content/operations/releases/release-2023-11.md
@@ -372,19 +372,32 @@ This release we have patched the following vulnerabilities in the Livingdocs Ser
 * [CVE-2023-45143](https://github.com/advisories/GHSA-wqq4-5wpv-mx2g) patched in `undici` v5.26.2
 * [CVE-2023-4863](https://nvd.nist.gov/vuln/detail/CVE-2023-4863) patched in `sharp` v0.32.6
 * [CVE-2023-26159](https://github.com/advisories/GHSA-jchw-25xp-jwwc) patched in `follow-redirects` v1.15.5
+* [CVE-2023-36665](https://github.com/advisories/GHSA-h755-8qp9-cq85) patched in `protobufjs` v7.2.5
+* [CVE-2024-28176](https://github.com/advisories/GHSA-hhhv-q57g-882q) patched in `jose` v4.15.5
+* [CVE-2024-28849](https://github.com/advisories/GHSA-cxjh-pqwp-8mfp) patched in `follow-redirects` v1.15.6
+* [CVE-2024-28863](https://github.com/advisories/GHSA-f5x3-32g6-xq36) patched in `tar` v6.2.1
+* [CVE-2024-29041](https://github.com/advisories/GHSA-rv95-896h-c2vc) patched in `express` v4.19.2
+* [CVE-2024-30260](https://github.com/advisories/GHSA-m4v8-wqvr-p9f7) patched in `undici` v5.28.4
+* [CVE-2024-30261](https://github.com/advisories/GHSA-9qxr-qj54-h672) patched in `undici` v5.28.4
 
-We are aware of the following vulnerabilities in the Livingdocs Editor:
+We are aware of the following vulnerabilities in the Livingdocs Server:
 
 * [CVE-2023-26102](https://cwe.mitre.org/data/definitions/1321.html) has yet to be patched by `rangy` but we have proposed a fix in [this PR](https://github.com/timdown/rangy/pull/482)
   This vulnerability is not exploitable in the Livingdocs Editor because `rangy` module is scoped in the `livingdocs-framework` and not exposed to the users.
 
 ### Livingdocs Editor :shield:
-
+This release we have patched the following vulnerabilities in the Livingdocs Editor:
 * [CVE-2023-43646](https://github.com/advisories/GHSA-4q6p-r6v2-jvc5) patched in `get-func-name` v2.0.2
 * [CVE-2023-45143](https://github.com/advisories/GHSA-wqq4-5wpv-mx2g) patched in `undici` v5.26.2
 * [CVE-2023-45133](https://github.com/advisories/GHSA-67hx-6x53-jw92) patched in `@babel/traverse`  v7.23.2
 * [CVE-2023-26159](https://github.com/advisories/GHSA-jchw-25xp-jwwc) patched in `follow-redirects` v1.15.5
 * [CVE-2023-51701](https://github.com/advisories/GHSA-v2v2-hph8-q5xp) patched in `@fastify/reply-from` v9.7.0
+* [CVE-2024-21501](https://github.com/advisories/GHSA-rm97-x556-q36h) patched in `sanitize-html` v2.12.1
+* [CVE-2024-28849](https://github.com/advisories/GHSA-cxjh-pqwp-8mfp) patched in `follow-redirects` v1.15.6
+* [CVE-2024-28863](https://github.com/advisories/GHSA-f5x3-32g6-xq36) patched in `tar` v6.2.1
+* [CVE-2024-29180](https://github.com/advisories/GHSA-wr3j-pwj9-hqq6) patched in `webpack-dev-middleware` v6.1.2
+* [CVE-2024-30260](https://github.com/advisories/GHSA-m4v8-wqvr-p9f7) patched in `undici` v5.28.4
+* [CVE-2024-30261](https://github.com/advisories/GHSA-9qxr-qj54-h672) patched in `undici` v5.28.4
 
 We are aware of the following vulnerabilities in the Livingdocs Editor:
 

--- a/content/operations/releases/release-2024-01.md
+++ b/content/operations/releases/release-2024-01.md
@@ -292,8 +292,15 @@ This feature has also been backported to `release-2023-11` and `release-2023-09`
 We are constantly patching module vulnerabilities for the Livingdocs Server and Livingdocs Editor as module fixes are available. Below is a list of all patched vulnerabilities included in the release.
 
 ### Livingdocs Server
-This release we have patched the following vulnerabilities in the Livingdocs Editor:
+This release we have patched the following vulnerabilities in the Livingdocs Server:
 * [CVE-2023-26159](https://github.com/advisories/GHSA-jchw-25xp-jwwc) patched in `follow-redirects` v1.15.5
+* [CVE-2023-36665](https://github.com/advisories/GHSA-h755-8qp9-cq85) patched in `protobufjs` v7.2.5
+* [CVE-2024-28176](https://github.com/advisories/GHSA-hhhv-q57g-882q) patched in `jose` v4.15.5
+* [CVE-2024-28849](https://github.com/advisories/GHSA-cxjh-pqwp-8mfp) patched in `follow-redirects` v1.15.6
+* [CVE-2024-28863](https://github.com/advisories/GHSA-f5x3-32g6-xq36) patched in `tar` v6.2.1
+* [CVE-2024-29041](https://github.com/advisories/GHSA-rv95-896h-c2vc) patched in `express` v4.19.2
+* [CVE-2024-30260](https://github.com/advisories/GHSA-m4v8-wqvr-p9f7) patched in `undici` v5.28.4
+* [CVE-2024-30261](https://github.com/advisories/GHSA-9qxr-qj54-h672) patched in `undici` v5.28.4
 
 No known vulnerabilities. :tada:
 
@@ -301,6 +308,12 @@ No known vulnerabilities. :tada:
 This release we have patched the following vulnerabilities in the Livingdocs Editor:
 * [CVE-2023-26159](https://github.com/advisories/GHSA-jchw-25xp-jwwc) patched in `follow-redirects` v1.15.5
 * [CVE-2023-51701](https://github.com/advisories/GHSA-v2v2-hph8-q5xp) patched in `@fastify/reply-from` v9.7.0
+* [CVE-2024-21501](https://github.com/advisories/GHSA-rm97-x556-q36h) patched in `sanitize-html` v2.12.1
+* [CVE-2024-28849](https://github.com/advisories/GHSA-cxjh-pqwp-8mfp) patched in `follow-redirects` v1.15.6
+* [CVE-2024-28863](https://github.com/advisories/GHSA-f5x3-32g6-xq36) patched in `tar` v6.2.1
+* [CVE-2024-29180](https://github.com/advisories/GHSA-wr3j-pwj9-hqq6) patched in `webpack-dev-middleware` v6.1.2
+* [CVE-2024-30260](https://github.com/advisories/GHSA-m4v8-wqvr-p9f7) patched in `undici` v5.28.4
+* [CVE-2024-30261](https://github.com/advisories/GHSA-9qxr-qj54-h672) patched in `undici` v5.28.4
 
 We are aware of the following vulnerabilities in the Livingdocs Editor:
 

--- a/content/operations/releases/release-2024-03.md
+++ b/content/operations/releases/release-2024-03.md
@@ -485,14 +485,29 @@ We are constantly patching module vulnerabilities for the Livingdocs Server and 
 
 ### Livingdocs Server
 
+This release we have patched the following vulnerabilities in the Livingdocs Server:
 * [CVE-2024-24758](https://github.com/advisories/GHSA-3787-6prv-h9w3) patched in `undici` v5.28.3
 * [GHSA-9h6g-pr28-7cqp](https://github.com/advisories/GHSA-9h6g-pr28-7cqp) patched in `nodemailer` v6.9.9
 * [CVE-2023-26159](https://github.com/advisories/GHSA-jchw-25xp-jwwc) patched in `follow-redirects` v1.15.4
+* [CVE-2024-28176](https://github.com/advisories/GHSA-hhhv-q57g-882q) patched in `jose` v4.15.5
+* [CVE-2024-28849](https://github.com/advisories/GHSA-cxjh-pqwp-8mfp) patched in `follow-redirects` v1.15.6
+* [CVE-2024-28863](https://github.com/advisories/GHSA-f5x3-32g6-xq36) patched in `tar` v6.2.1
+* [CVE-2024-29041](https://github.com/advisories/GHSA-rv95-896h-c2vc) patched in `express` v4.19.2
+* [CVE-2024-30260](https://github.com/advisories/GHSA-m4v8-wqvr-p9f7) patched in `undici` v5.28.4
+* [CVE-2024-30261](https://github.com/advisories/GHSA-9qxr-qj54-h672) patched in `undici` v5.28.4
+
+No known vulnerabilities. :tada:
 
 ### Livingdocs Editor
+This release we have patched the following vulnerabilities in the Livingdocs Editor:
 * [CVE-2024-24758](https://github.com/advisories/GHSA-3787-6prv-h9w3) patched in `undici` v5.28.3
 * [CVE-2023-26159](https://github.com/advisories/GHSA-jchw-25xp-jwwc) patched in `follow-redirects` v1.15.4
 * [CVE-2023-51701](https://github.com/fastify/fastify-reply-from/security/advisories/GHSA-v2v2-hph8-q5xp) patched in `@fastify/reply-from` v9.6.0
+* [CVE-2024-28849](https://github.com/advisories/GHSA-cxjh-pqwp-8mfp) patched in `follow-redirects` v1.15.6
+* [CVE-2024-28863](https://github.com/advisories/GHSA-f5x3-32g6-xq36) patched in `tar` v6.2.1
+* [CVE-2024-29180](https://github.com/advisories/GHSA-wr3j-pwj9-hqq6) patched in `webpack-dev-middleware` v6.1.2
+* [CVE-2024-30260](https://github.com/advisories/GHSA-m4v8-wqvr-p9f7) patched in `undici` v5.28.4
+* [CVE-2024-30261](https://github.com/advisories/GHSA-9qxr-qj54-h672) patched in `undici` v5.28.4
 
 We are aware of the following vulnerabilities in the Livingdocs Editor:
 

--- a/content/operations/releases/release-2024-05.md
+++ b/content/operations/releases/release-2024-05.md
@@ -181,9 +181,23 @@ TODO (featureset not 100% defined yet)
 We are constantly patching module vulnerabilities for the Livingdocs Server and Livingdocs Editor as module fixes are available. Below is a list of all patched vulnerabilities included in the release.
 
 ### Livingdocs Server
+This release we have patched the following vulnerabilities in the Livingdocs Server:
+* [CVE-2024-28863](https://github.com/advisories/GHSA-f5x3-32g6-xq36) patched in `tar` v6.2.1
+* [CVE-2024-30260](https://github.com/advisories/GHSA-m4v8-wqvr-p9f7) patched in `undici` v5.28.4
+* [CVE-2024-30261](https://github.com/advisories/GHSA-9qxr-qj54-h672) patched in `undici` v5.28.4
+
+No known vulnerabilities. :tada:
 
 ### Livingdocs Editor
+This release we have patched the following vulnerabilities in the Livingdocs Editor:
+* [CVE-2024-28863](https://github.com/advisories/GHSA-f5x3-32g6-xq36) patched in `tar` v6.2.1
+* [CVE-2024-30260](https://github.com/advisories/GHSA-m4v8-wqvr-p9f7) patched in `undici` v5.28.4
+* [CVE-2024-30261](https://github.com/advisories/GHSA-9qxr-qj54-h672) patched in `undici` v5.28.4
 
+We are aware of the following vulnerabilities in the Livingdocs Editor:
+
+* [CVE-2023-44270](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) vulnerability in `postcss`, it affects linters using PostCSS to parse external Cascading Style Sheets (CSS). It is not exploitable in the editor as we don't load untrusted external CSS at build time.
+* [CVE-2023-26116](https://cwe.mitre.org/data/definitions/1333.html), [CVE-2023-26118](https://cwe.mitre.org/data/definitions/1333.html), [CVE-2023-26117](https://cwe.mitre.org/data/definitions/1333.html), [CVE-2022-25869](https://cwe.mitre.org/data/definitions/79.html), [CVE-2022-25844](https://cwe.mitre.org/data/definitions/770.html) are all AngularJS vulnerabilities that don't have a patch available. We are working on removing all AngularJS from our code and vulnerabilities will go away when we complete the transition to Vue.js.
 
 ## Patches
 


### PR DESCRIPTION
We have patched vulnerabilities in all supported releases and we want customers to know they have been patched. This PR adds information on what was patched and to which release it was patched.