### PR TITLE
fix(composition api): clarity on fields vs includes

### DIFF
--- a/content/reference/public-api/composition-api.md
+++ b/content/reference/public-api/composition-api.md
@@ -37,7 +37,7 @@ POST api/beta/composition/:documentId
 |-|-|-|
 |fields|array\<string>|A list of the properties which should be computed and returned.<br>Default: ['systemdata', 'content', 'metadata', 'includes', 'html', 'design']|
 |metadata.preload|object|You can pass metadata properties which should be resolved.<br>This only works for properties of type 'li-document-reference', 'li-document-references', 'li-list-reference' and 'li-tree'<br>Example: `{metadata: {preload: {myProp: true}}}`|
-|resolveIncludes|boolean|Resolve includes. If `true` then 'includes' will be populated and includes will be resolved in the rendered `html`|
+|resolveIncludes|boolean|Resolve includes. If `true` then 'includes' will be populated and includes will be resolved in the rendered `html`. If 'includes' is added to the fields array as above, they are resolved in a separate array from the content.|
 |renderOptions.renderDirectiveInfo|boolean|Add attributes with the directive name to directive elements.|
 |ignoreComponentConditions|boolean|Provides a way to opt out of component filtering and return all content regardless of whether each component passes the conditional checks.<br>{{< added-in "release-2024-03" >}}<br>Default: `false`|
 |componentConditions|string|JSON stringified object which contains the component conditions you would like to apply.<br>{{< added-in "release-2024-03" >}}<br>Default: `dateTime: new Date()`<br>Example: `?componentConditions={"dateTime":"2024-02-14T17:25:10.391Z"}`|


### PR DESCRIPTION
Whilst using the composition API today I noticed that if you add `fields: ['includes']` and `resolveIncludes: true` then the content does not resolve the includes, they are only resolved in the separate array. 

I added this as a simple sentence to make sure people don't do what I did and spend ages thinking my include service wasn't resolving anything! 