### PR TITLE
Release-2024-05 dashboard deprecations

### DIFF
--- a/content/operations/releases/release-2024-05.md
+++ b/content/operations/releases/release-2024-05.md
@@ -166,6 +166,8 @@ editorSettings: {
 {{< feature-info "Dashboards" "server" >}}
 ### Dashboards of type `dashboard` :warning:
 
+Livingdocs provides with Table Dashboards a structured and customizable approach to searching and managing documents. Since `release-2022-09`, they are the recommended way to create dashboards. Therefore, we are deprecating dashboards of type `dashboard` and will remove support for them in `release-2024-11`. Customers using dashboards of type `dashboard` should migrate to `tableDashboard`.
+
 {{< feature-info "Dashboards" "server" >}}
 ### Angular custom dashboard cards :warning:
 

--- a/content/operations/releases/release-2024-05.md
+++ b/content/operations/releases/release-2024-05.md
@@ -171,6 +171,7 @@ Livingdocs provides with Table Dashboards a structured and customizable approach
 {{< feature-info "Dashboards" "server" >}}
 ### Angular custom dashboard cards :warning:
 
+As part of our ongoing migration from Angular to Vue, we are deprecating Angular dashboard cards and will remove support for them in `release-2024-11`. Custom dashboard cards are currently supported in media library dashboards and dashboards of type `kanbanBoard`, `taskBoard`, and `dashboard` (deprecated, see  [Deprecating dashboards of type `dashboard`]({{< relref "#dashboards-of-type-dashboard-warning" >}})). If you are affected by this change, you should consider using the provided upstream dashboard cards instead. If these do not meet your requirements, please migrate your custom dashboard cards to Vue components.
 
 ## Features
 


### PR DESCRIPTION
- Add deprecation of dashboards of type `dashboard` to release notes
- Add deprecation of custom Angular dashboard cards to release notes