### PR TITLE
fix(analytics): change google analytics path

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,6 @@ enableGitInfo: true
 enableEmoji: true
 enableInlineShortcodes: true
 enableRobotsTXT: true
-googleAnalytics: GTM-K6QTH5K
 
 markup:
   goldmark:
@@ -29,6 +28,10 @@ markup:
     endLevel: 4
     ordered: false
     startLevel: 1
+
+services:
+  googleAnalytics:
+    id: GTM-K6QTH5K
 
 imaging:
   quality: 75

--- a/themes/hugo-docs/layouts/partials/html-header.html
+++ b/themes/hugo-docs/layouts/partials/html-header.html
@@ -19,7 +19,7 @@
   {{- $worker := resources.Get "search.js" | js.Build }}
   <link rel="lunr" href="{{ $worker.RelPermalink }}">
 
-  {{- with .Site.GoogleAnalytics }}
+  {{- with .Site.Config.Services.GoogleAnalytics.ID }}
   <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
     j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=


### PR DESCRIPTION
Had a Hugo deprecation error in the newest version even though it should only be removed from hugo v 0.135.0 on with hugo version `0.134.2` 🤷

> ERROR deprecated: .Site.GoogleAnalytics was deprecated in Hugo v0.120.0 and will be removed in Hugo 0.135.0. Use .Site.Config.Services.GoogleAnalytics.ID instead.