### PR TITLE
Update release notes for latest releases to include latest security patches

### DIFF
--- a/content/operations/releases/release-2024-05.md
+++ b/content/operations/releases/release-2024-05.md
@@ -536,6 +536,9 @@ This release we have patched the following vulnerabilities in the Livingdocs Ser
 * [CVE-2024-30261](https://github.com/advisories/GHSA-9qxr-qj54-h672) patched in `undici` v5.28.4
 * [CVE-2024-37168](https://github.com/advisories/GHSA-7v5v-9h63-cj86) patched in `@grpc/grpc-js` v1.9.15
 * [CVE-2024-37890](https://github.com/advisories/GHSA-3h5v-q93c-6h6q) patched in `ws` v8.17.1
+* [CVE-2024-43799](https://nvd.nist.gov/vuln/detail/CVE-2024-43799) patched in `send` v0.19.0
+* [CVE-2024-45296](https://nvd.nist.gov/vuln/detail/CVE-2024-45296) patched in `path-to-regexp` v6.3.0
+* [CVE-2024-47764](https://nvd.nist.gov/vuln/detail/CVE-2024-47764) patched in `cookie` v0.7.0
 
 No known vulnerabilities. :tada:
 
@@ -549,6 +552,9 @@ This release we have patched the following vulnerabilities in the Livingdocs Edi
 * [CVE-2024-30261](https://github.com/advisories/GHSA-9qxr-qj54-h672) patched in `undici` v5.28.4
 * [CVE-2024-37890](https://github.com/advisories/GHSA-3h5v-q93c-6h6q) patched in `ws` v8.17.1
 * [CVE-2024-42459](https://nvd.nist.gov/vuln/detail/CVE-2024-42459) patched in `elliptic` v6.5.7
+* [CVE-2024-45296](https://nvd.nist.gov/vuln/detail/CVE-2024-45296) patched in `path-to-regexp` v6.3.0
+* [CVE-2024-45590](https://nvd.nist.gov/vuln/detail/CVE-2024-45296) patched in `body-parser` v1.20.3
+* [CVE-2024-45813](https://nvd.nist.gov/vuln/detail/CVE-2024-45813) patched in `find-my-way` v8.2.2
 
 We are aware of the following vulnerabilities in the Livingdocs Editor:
 

--- a/content/operations/releases/release-2024-07.md
+++ b/content/operations/releases/release-2024-07.md
@@ -352,6 +352,9 @@ This release we have patched the following vulnerabilities in the Livingdocs Ser
 * [CVE-2024-4068](https://github.com/advisories/GHSA-grv7-fg5c-xmjg) patched in `braces` v3.0.3
 * [CVE-2024-37168](https://github.com/advisories/GHSA-7v5v-9h63-cj86) patched in `@grpc/grpc-js` v1.9.15
 * [CVE-2024-37890](https://github.com/advisories/GHSA-3h5v-q93c-6h6q) patched in `ws` v8.17.1
+* [CVE-2024-43799](https://nvd.nist.gov/vuln/detail/CVE-2024-43799) patched in `send` v0.19.0
+* [CVE-2024-45296](https://nvd.nist.gov/vuln/detail/CVE-2024-45296) patched in `path-to-regexp` v6.3.0
+* [CVE-2024-47764](https://nvd.nist.gov/vuln/detail/CVE-2024-47764) patched in `cookie` v0.7.0
 
 No known vulnerabilities. :tada:
 
@@ -362,6 +365,9 @@ This release we have patched the following vulnerabilities in the Livingdocs Edi
 * [CVE-2024-4367](https://github.com/advisories/GHSA-wgrm-67xf-hhpq) patched in `pdfjs-dist` v4.3.136
 * [CVE-2024-37890](https://github.com/advisories/GHSA-3h5v-q93c-6h6q) patched in `ws` v8.17.1
 * [CVE-2024-42459](https://nvd.nist.gov/vuln/detail/CVE-2024-42459) patched in `elliptic` v6.5.7
+* [CVE-2024-45296](https://nvd.nist.gov/vuln/detail/CVE-2024-45296) patched in `path-to-regexp` v6.3.0
+* [CVE-2024-45590](https://nvd.nist.gov/vuln/detail/CVE-2024-45296) patched in `body-parser` v1.20.3
+* [CVE-2024-45813](https://nvd.nist.gov/vuln/detail/CVE-2024-45813) patched in `find-my-way` v8.2.2
 
 We are aware of the following vulnerabilities in the Livingdocs Editor:
 

--- a/content/operations/releases/release-2024-09.md
+++ b/content/operations/releases/release-2024-09.md
@@ -416,7 +416,10 @@ This release we have patched the following vulnerabilities in the Livingdocs Ser
 * [CVE-2024-38372](https://nvd.nist.gov/vuln/detail/CVE-2024-38372) patched in `undici` v6.19.2
 * [CVE-2024-39338](https://nvd.nist.gov/vuln/detail/CVE-2024-39338) patched in `axios` v1.7.4
 * [CVE-2024-41818](https://nvd.nist.gov/vuln/detail/CVE-2024-41818) patched in `fast-xml-parser` v4.4.1
-* [CVE-2024-43796](https://nvd.nist.gov/vuln/detail/CVE-2024-43796) patched in `express` 4.20.0
+* [CVE-2024-43796](https://nvd.nist.gov/vuln/detail/CVE-2024-43796) patched in `express` v4.20.0
+* [CVE-2024-43799](https://nvd.nist.gov/vuln/detail/CVE-2024-43799) patched in `send` v0.19.0
+* [CVE-2024-45296](https://nvd.nist.gov/vuln/detail/CVE-2024-45296) patched in `path-to-regexp` v6.3.0
+* [CVE-2024-47764](https://nvd.nist.gov/vuln/detail/CVE-2024-47764) patched in `cookie` v0.7.0
 
 No known vulnerabilities. :tada:
 
@@ -426,6 +429,9 @@ This release we have patched the following vulnerabilities in the Livingdocs Edi
 * [CVE-2024-39338](https://nvd.nist.gov/vuln/detail/CVE-2024-39338) patched in `axios` v1.7.4
 * [CVE-2024-42459](https://nvd.nist.gov/vuln/detail/CVE-2024-42459) patched in `elliptic` v6.5.7
 * [CVE-2024-43788](https://nvd.nist.gov/vuln/detail/CVE-2024-43788) patched in `webpack` v5.94.0
+* [CVE-2024-45296](https://nvd.nist.gov/vuln/detail/CVE-2024-45296) patched in `path-to-regexp` v6.3.0
+* [CVE-2024-45813](https://nvd.nist.gov/vuln/detail/CVE-2024-45813) patched in `find-my-way` v8.2.2
+* [CVE-2024-47764](https://nvd.nist.gov/vuln/detail/CVE-2024-47764) patched in `cookie` v0.7.0
 
 We are aware of the following vulnerabilities in the Livingdocs Editor:
 

--- a/content/operations/releases/release-2024-11.md
+++ b/content/operations/releases/release-2024-11.md
@@ -156,14 +156,16 @@ We are constantly patching module vulnerabilities for the Livingdocs Server and 
 
 ### Livingdocs Server
 This release we have patched the following vulnerabilities in the Livingdocs Server:
-- TBD
+* [CVE-2024-45813](https://nvd.nist.gov/vuln/detail/CVE-2024-45813) patched in `find-my-way` v8.2.2
+* [CVE-2024-47764](https://nvd.nist.gov/vuln/detail/CVE-2024-47764) patched in `cookie` v0.7.0
 
 No known vulnerabilities. :tada:
 
 ### Livingdocs Editor
 This release we have patched the following vulnerabilities in the Livingdocs Editor:
-
-- TBD
+* [CVE-2024-45296](https://nvd.nist.gov/vuln/detail/CVE-2024-45296) patched in `path-to-regexp` v6.3.0
+* [CVE-2024-45813](https://nvd.nist.gov/vuln/detail/CVE-2024-45813) patched in `find-my-way` v8.2.2
+* [CVE-2024-47764](https://nvd.nist.gov/vuln/detail/CVE-2024-47764) patched in `cookie` v0.7.0
 
 We are aware of the following vulnerabilities in the Livingdocs Editor:
 


### PR DESCRIPTION
Relations:
- Related PRs: https://github.com/livingdocsIO/livingdocs-server/pull/7355 https://github.com/livingdocsIO/livingdocs-editor/pull/9084

We want to keep vulnerability updates on the documentation, including old releases.