### PR TITLE
Add documentation for new commands

### DIFF
--- a/content/operations/releases/release-2024-11.md
+++ b/content/operations/releases/release-2024-11.md
@@ -164,13 +164,9 @@ livingdocs-server migrate up
 
 
 {{< feature-info "Command API" "server" >}}
-### Command API `insertComponent` validation :fire:
+### Stricter Document Command API `insertComponent` Validation :fire:
 
-
-{{< feature-info "Search" "server" >}}
-### Strict `limit` validation for `li-document-search` :fire:
-
-
+We have made the validation of the `insertComponent` command stricter. Previously, any component available in the design could be inserted into a document with the `insertComponent` command, even if it wasn’t configured in the content type. Now, only components configured in the content type can be inserted, and attempting to insert an unconfigured component will result in a validation error.
 
 ## Deprecations
 
@@ -204,8 +200,103 @@ livingdocs-server migrate up
 
 
 {{< feature-info "Command API" "server" >}}
-### Command API enhancements :gift:
+### Document Command API: New Commands :gift:
 
+We have extended the [Document Command API]({{< ref "/reference/public-api/document-command-api" >}}) with five new commands, which are also available for [Assistants]({{< ref "/customising/assistants" >}}).
+
+Each command supports an optional `oldValue` parameter. When specified, the system verifies that the value being updated matches the provided `oldValue`. This prevents accidental overwrites that might occur due to changes made between reading a document and issuing the command. If the `oldValue` does not match, a conflict error is thrown.
+
+#### `setComponentCondition`
+
+```js
+{
+  operation: 'setComponentCondition',
+  componentId: 'doc-123',
+  conditionName: 'dateTime',
+  value: {
+    gte: '2025-01-01T10:30:00.000Z',
+    lt: '2025-02-02T14:30:00.000Z'
+  },
+  oldValue: {
+    gte: '2024-01-01T10:30:00.000Z',
+    lt: '2024-02-02T14:30:00.000Z'
+  }
+}
+```
+
+#### `setComponentStyle`
+
+```js
+{
+  operation: 'setComponentStyle',
+  componentId: 'doc-123',
+  propertyName: 'background',
+  value: '#1fc47a',
+  oldValue: '#000'
+}
+```
+
+#### `setStyleDirective`
+
+```js
+{
+  operation: 'setStyleDirective',
+  componentId: 'doc-123',
+  directiveName: 'appearance',
+  propertyName: 'background',
+  value: '#1fc47a',
+  oldValue: '#000'
+}
+```
+
+#### `setLinkDirective`
+
+```js
+{
+  operation: 'setLinkDirective',
+  componentId: 'doc-123',
+  directiveName: 'link',
+  value: {
+    href: 'https://livingdocs.io/article/123',
+    target: '_blank',
+    $ref: 'document',
+    reference: {id: '123'}
+  },
+  oldValue: {
+    href: 'https://livingdocs.io/'
+  }
+}
+```
+
+#### `setIncludeDirective`
+
+The `setIncludeDirective` command supports updating both include `params` and `overrides`. These properties depend on each other: if only `params` are provided, any existing `overrides` are removed. Conversely, specifying `overrides` without `params` is invalid and will return a validation error. To update `overrides`, both the `params` and `overrides` properties must be provided.
+
+```js
+{
+  operation: 'setIncludeDirective',
+  componentId: 'doc-123',
+  directiveName: 'related-article',
+  value: {
+    params: {
+      teaser: {
+        $ref: 'document',
+        reference: {id: '3'}
+      },
+    },
+    overrides: [{
+      id: 'teaser-normal-3',
+      content: {
+        link: {href: 'https://livingdocs.io'},
+        title: 'Changed title',
+      },
+      originalSnapshot: {...},
+      contentProperties: [...]
+    }]
+  },
+  oldValue: null
+}
+```
 
 {{< feature-info "Assistants" "server" >}}
 ### Assistants: Component Trigger :gift:

--- a/content/operations/releases/release-2024-11.md
+++ b/content/operations/releases/release-2024-11.md
@@ -208,6 +208,8 @@ Each command supports an optional `oldValue` parameter. When specified, the syst
 
 #### `setComponentCondition`
 
+The `setComponentCondition` command updates a component condition. Currently, only conditions of type `dateTime` are supported.
+
 ```js
 {
   operation: 'setComponentCondition',
@@ -226,6 +228,8 @@ Each command supports an optional `oldValue` parameter. When specified, the syst
 
 #### `setComponentStyle`
 
+The `setComponentStyle` command updates a component style. It supports all types: `style`, `option`, and `select`.
+
 ```js
 {
   operation: 'setComponentStyle',
@@ -237,6 +241,8 @@ Each command supports an optional `oldValue` parameter. When specified, the syst
 ```
 
 #### `setStyleDirective`
+
+The `setStyleDirective` command updates a style directive. It supports all types: `style`, `option`, and `select`.
 
 ```js
 {
@@ -250,6 +256,8 @@ Each command supports an optional `oldValue` parameter. When specified, the syst
 ```
 
 #### `setLinkDirective`
+
+The `setLinkDirective` command updates a link directive.
 
 ```js
 {
@@ -270,7 +278,7 @@ Each command supports an optional `oldValue` parameter. When specified, the syst
 
 #### `setIncludeDirective`
 
-The `setIncludeDirective` command supports updating both include `params` and `overrides`. These properties depend on each other: if only `params` are provided, any existing `overrides` are removed. Conversely, specifying `overrides` without `params` is invalid and will return a validation error. To update `overrides`, both the `params` and `overrides` properties must be provided.
+The `setIncludeDirective` command updates an include directive. It supports both include `params` and `overrides`. These properties depend on each other: if only `params` are provided, any existing `overrides` are removed. Conversely, specifying `overrides` without `params` is invalid and will return a validation error. To update `overrides`, both the `params` and `overrides` properties must be provided.
 
 ```js
 {

--- a/content/reference/public-api/document-command-api.md
+++ b/content/reference/public-api/document-command-api.md
@@ -106,7 +106,7 @@ PATCH api/v1/documents/:id/commands
       }
     },
     {
-      // Updates a component style.
+      // Updates a component style. It supports all types: style, option, and select.
       "operation": "setComponentStyle",
       "componentId": "doc-123",
       "propertyName": "background",
@@ -164,7 +164,7 @@ PATCH api/v1/documents/:id/commands
       }
     },
     {
-      // Updates a style directive.
+      // Updates a style directive. It supports all types: style, option, and select.
       "operation": "setStyleDirective",
       "componentId": "doc-123",
       "directiveName": "appearance",

--- a/content/reference/public-api/document-command-api.md
+++ b/content/reference/public-api/document-command-api.md
@@ -209,8 +209,16 @@ api/v1/documents/:id/commands
   "status": 400,
   "error": "Bad Request",
   "error_details": {
-    "commands.0.operation": "value of tag \"operation\" must be in oneOf",
-    "commandIndex": 0
+    "commands.0": "value of tag \"operation\" must be in oneOf"
+  }
+}
+// or
+{
+  "status": 400,
+  "error": "Bad Request",
+  "error_details": {
+    "commands.0.value": "must match exactly one schema in oneOf",
+    "commands.0.value.params": "Missing required property: params"
   }
 }
 // or
@@ -237,6 +245,15 @@ api/v1/documents/:id/commands
   "error": "Bad Request",
   "error_details": {
     "message": "Command at index 0 failed: Directive 'my-directive' of type 'editable' does not exist on component 'doc-123' in document '123'",
+    "commandIndex": 0
+  }
+}
+// or
+{
+  "status": 400,
+  "error": "Bad Request",
+  "error_details": {
+    "message": "Command at index 0 failed: Include validation failed: {\"title\":\"Invalid type: expected string\",\"teasers.limit\":\"Missing required property: limit\",\"teasers.invalid\":\"Additional properties not allowed\"}",
     "commandIndex": 0
   }
 }

--- a/content/reference/public-api/document-command-api.md
+++ b/content/reference/public-api/document-command-api.md
@@ -7,8 +7,6 @@ menus:
     parent: Public API
 ---
 
-{{< added-in "release-2023-11" block >}}
-
 {{< api-example
 title="Execute Commands on Documents"
 scopes="public-api:write"
@@ -23,7 +21,11 @@ curl -k -X PATCH "https://server.livingdocs.io/api/v1/documents/:id/commands" \
   -H "Authorization: Bearer $ACCESS_TOKEN" \
   --data-binary @- << EOF
   {
-    "commands": [{"operation": "setMetadataProperty", "propertyName": "title", "value": "updated title"}]
+    "commands": [{
+      "operation": "setMetadataProperty",
+      "propertyName": "title",
+      "value": "updated title"
+    }]
   }
 EOF
 ```
@@ -38,7 +40,7 @@ PATCH api/v1/documents/:id/commands
 |-|-|-|-|
 |version|integer||Current document version. When set on update the version is checked.|
 |preconditions|array||An array of preconditions for command execution. If a precondition assertion fails, no commands are executed and the request responds with a `429 Conflict` status.<br><br>Each entry is an object with at least a **type** property.<br><br>Possible types:<br>- `isPublished`: Document is currently public<br>- `isPublishedAndHasNoChanges`: Document is currently public and has no changes since last publish<br><br>See further details in example requests.|
-|commands|array|x|An array of commands to execute. Each entry is an object with at least an **operation** property.<br><br>Possible operations:<br>- `setMetadataProperty`<br>- `setEditableDirective`<br>- `setTitle`<br>- `insertComponent` {{< added-in "release-2024-05" >}}<br>- `removeComponent` {{< added-in "release-2024-07" >}}<br>- `publish`<br>- `unpublish` {{< added-in "release-2024-07" >}}<br><br>See further details in example requests.|
+|commands|array|x|An array of commands to execute. Each entry is an object with at least an **operation** property.<br><br>Possible operations:<br>- `setMetadataProperty`<br>- `setTitle`<br>- `insertComponent` {{< added-in "release-2024-05" >}}<br>- `removeComponent` {{< added-in "release-2024-07" >}}<br>- `setComponentCondition` {{< added-in "release-2024-11" >}}<br>- `setComponentStyle` {{< added-in "release-2024-11" >}}<br>- `setEditableDirective`<br>- `setIncludeDirective` {{< added-in "release-2024-11" >}}<br>- `setLinkDirective` {{< added-in "release-2024-11" >}}<br>- `setStyleDirective` {{< added-in "release-2024-11" >}}<br>- `publish`<br>- `unpublish` {{< added-in "release-2024-07" >}}<br><br>Some commands supports an optional `oldValue` parameter. When specified, the system verifies that the value being updated matches the provided `oldValue`. This prevents accidental overwrites that might occur due to changes made between reading a document and issuing the command. If the `oldValue` does not match, a conflict error is thrown. `oldValue` is redundant when providing a document version.<br><br>See further details in example requests.|
 
 #### Example Request
 ```js
@@ -60,13 +62,6 @@ PATCH api/v1/documents/:id/commands
       "propertyName": "title",
       "value": "updated title", // send null to delete metadata property
       "oldValue": "previous title" // optional, for conflict detection (not necessary when sending document version too)
-    },
-    {
-      // Sets the content of an editable directive.
-      "operation": "setEditableDirective",
-      "componentId": "doc-1a2b3c4d5",
-      "directiveName": "headline",
-      "value": "updated headline"
     },
     {
       // Sets the title property on a document (might be overruled by displayTitlePattern on read).
@@ -94,6 +89,88 @@ PATCH api/v1/documents/:id/commands
       // Does not work if component or parent component has `position: 'fixed'`
       "operation": "removeComponent",
       "componentId": "doc-4a2b3g4d5"
+    },
+    {
+      // Updates a component condition. Currently, only "dateTime" conditions
+      // are supported.
+      "operation": "setComponentCondition",
+      "componentId": "doc-123",
+      "conditionName": "dateTime",
+      "value": {
+        "gte": "2025-01-01T10:30:00.000Z",
+        "lt": "2025-02-02T14:30:00.000Z"
+      },
+      "oldValue": {
+        "gte": "2024-01-01T10:30:00.000Z",
+        "lt": "2024-02-02T14:30:00.000Z"
+      }
+    },
+    {
+      // Updates a component style.
+      "operation": "setComponentStyle",
+      "componentId": "doc-123",
+      "propertyName": "background",
+      "value": "#1fc47a",
+      "oldValue": "#000"
+    },
+    {
+      // Sets the content of an editable directive.
+      "operation": "setEditableDirective",
+      "componentId": "doc-1a2b3c4d5",
+      "directiveName": "headline",
+      "value": "updated headline"
+    },
+    {
+      // Updates params and overrides of an include directive. These properties
+      // depend on each other: if only params are provided, any existing
+      // overrides are removed. Conversely, specifying overrides without params
+      // is invalid and will return a validation error. To update overrides,
+      // both the params and overrides properties must be provided.
+      "operation": "setIncludeDirective",
+      "componentId": "doc-123",
+      "directiveName": "related-article",
+      "value": {
+        "params": {
+          "teaser": {
+            "$ref": "document",
+            "reference": {id: "3"}
+          },
+        },
+        "overrides": [{
+          "id": "teaser-normal-3",
+          "content": {
+            "link": {"href": "https://livingdocs.io"},
+            "title": "Changed title",
+          },
+          "originalSnapshot": {...},
+          "contentProperties": [...]
+        }]
+      },
+      "oldValue": null
+    },
+    {
+      // Updates a link directive.
+      "operation": "setLinkDirective",
+      "componentId": "doc-123",
+      "directiveName": "link",
+      "value": {
+        "href": "https://livingdocs.io/article/123",
+        "target": "_blank",
+        "$ref": "document",
+        "reference": {"id": "123"}
+      },
+      "oldValue": {
+        "href": "https://livingdocs.io/"
+      }
+    },
+    {
+      // Updates a style directive.
+      "operation": "setStyleDirective",
+      "componentId": "doc-123",
+      "directiveName": "appearance",
+      "propertyName": "background",
+      "value": "#1fc47a",
+      "oldValue": "#000"
     },
     {
       // Creates a new publication for the document if applicable
@@ -150,7 +227,16 @@ api/v1/documents/:id/commands
   "status": 400,
   "error": "Bad Request",
   "error_details": {
-    "message": "Command at index 0 failed: Component with id doc-00000000 and directive name title does not exist on document with id 123",
+    "message": "Command at index 0 failed: Component 'doc-123' does not exist in document '123'",
+    "commandIndex": 0
+  }
+}
+// or
+{
+  "status": 400,
+  "error": "Bad Request",
+  "error_details": {
+    "message": "Command at index 0 failed: Directive 'my-directive' of type 'editable' does not exist on component 'doc-123' in document '123'",
     "commandIndex": 0
   }
 }
@@ -193,6 +279,15 @@ api/v1/documents/:id/commands
   "error_details": {
     "name": "Conflict",
     "message": "Precondition failed: 'isPublished'"
+  }
+}
+// or
+{
+  "status": 409,
+  "error": "Conflict",
+  "error_details": {
+    "name": "Conflict",
+    "message": "Cannot update outdated value'"
   }
 }
 ```


### PR DESCRIPTION
Relations:

- https://github.com/livingdocsIO/livingdocs-server/pull/7373
- https://github.com/livingdocsIO/livingdocs-server/pull/7405
- https://github.com/livingdocsIO/livingdocs-server/pull/7395

New commands:

- `setComponentCondition`
- `setComponentStyle`
- `setIncludeDirective`
- `setLinkDirective`
- `setStyleDirective`