### PR TITLE
fix: fix typo in db migration name

### DIFF
--- a/content/operations/releases/release-2024-11.md
+++ b/content/operations/releases/release-2024-11.md
@@ -70,7 +70,7 @@ Related to migration of `document_metadata` table to `document_revisions` table.
 **Please make sure you have a few gigabytes of storage available in postgres before executing that command. It will rewrite all metadata and will probably take a while.**
 
 ```sh
-node db/manual-migrations/011-move-metadata.js 
+node db/manual-migrations/011-move-revision-metadata.js 
 ```
 
 After executing this script, the `document_metadata` table will get truncated and clean up storage.
@@ -123,7 +123,7 @@ A rollback of already upgraded data takes a bit longer as it needs to scan the w
 After the upgrade succeeded and it's definitive that you won't need to roll back (a few days), it's best to migrate all data to the new structure. To do that you can execute the command below. **Please make sure you have a few gigabytes of storage available in postgres before executing that command. It will rewrite all metadata probably takes a while.** We've tested the script against a database with 4'300'000 revision entries and it took ~7 minutes. After executing that script, the `document_metadata` table will get truncated and clean up storage.
 
 ```sh
-node db/manual-migrations/011-move-metadata.js 
+node db/manual-migrations/011-move-revision-metadata.js 
 ```
 
 {{< feature-info "Command API" "server" >}}


### PR DESCRIPTION
November release notes instruct to run this migration
`node db/manual-migrations/011-move-metadata.js `
It is probably actually referring to this one `011-move-revision-metadata`.

I updated it, waiting for your confirmation that this assumption was correct :) 