### PR TITLE
fix(deliveries docs): point out they must be empty config

### DIFF
--- a/content/reference/project-config/deliveries.md
+++ b/content/reference/project-config/deliveries.md
@@ -115,3 +115,10 @@ build: {
 ```
 
 To enable Delivery Builds on a document, you must also configure `deliveries` in the [contentType]({{< ref "./content-types.md" >}}) config.
+
+
+If you have delivery builds configured in your project but you specifically do not want them on a specific contentType, you must configure an empty array inside of the contentType itself:
+
+```js
+deliveries: []
+```


### PR DESCRIPTION
The deliveries need to be an empty array to not appear on a contentType. 

This updates the docs to explain this.