### PR TITLE
Update Hugo to an up-to-date version in the CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM livingdocs/node:18 as builder
+FROM alpine:3 as builder
 ADD package*.json /app/
 WORKDIR /app
-RUN apk add hugo && npm ci
+RUN apk add git hugo nodejs npm && npm ci
 ADD . /app
 RUN npm run build
 


### PR DESCRIPTION
The changes in [this commit](https://github.com/livingdocsIO/documentation/commit/c2c4b00119d40a628b1d4558528923a33a8d72cb) unfortunately broke the build system. Currently, the Hugo version used in the CI is v0.111.3, but the changes require v0.128.0.

Previously, we used the `nodejs/docker-node` image as the base Docker image. However, no version of this image uses Alpine v3.21, which is the only Alpine version that provides a recent enough Hugo version in its package repository. For this reason, I changed the Docker base image of the build container.