### PR TITLE
Revert gohugo deprecations fix

### DIFF
--- a/themes/hugo-docs/layouts/index.searchindex.json
+++ b/themes/hugo-docs/layouts/index.searchindex.json
@@ -6,7 +6,7 @@
     {{- $entry = merge $entry (dict "categories" $page.Params.categories) -}}
     {{- $entry = merge $entry (dict "keywords" $page.Params.keywords) -}}
     {{- $entry = merge $entry (dict "title" $page.Title) -}}
-    {{- $entry = merge $entry (dict "description" ($page.Description | .Page.RenderString | plainify)) -}}
+    {{- $entry = merge $entry (dict "description" ($page.Description | markdownify | plainify)) -}}
     {{- $entry = merge $entry (dict "body" ($page.Content | jsonify)) -}}
     {{- if ne $page.Params.excludeFromSearch true -}}
       {{- if ne $index 0 -}} , {{- end -}}

--- a/themes/hugo-docs/layouts/partials/html-header.html
+++ b/themes/hugo-docs/layouts/partials/html-header.html
@@ -9,11 +9,11 @@
   <link rel="canonical" href="{{ .Permalink }}">
   <title>{{ .Page.Title }} - {{.Section | default "Documentation" | humanize}}</title>
 
-  {{- $built := resources.Get "style.scss" | css.Sass | minify | fingerprint }}
+  {{- $built := resources.Get "style.scss" | resources.ToCSS | resources.Minify | fingerprint }}
   <link rel="stylesheet" href="{{ $built.RelPermalink }}">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,400;0,500;1,400;1,500&display=swap" rel="preload">
 
-  {{- $built := resources.Get "script.js" | js.Build | minify | fingerprint }}
+  {{- $built := resources.Get "script.js" | js.Build | resources.Minify | fingerprint }}
   <script>window.searchJson = '/search.json'</script>
   <script type="text/javascript" src="{{ $built.RelPermalink }}" defer></script>
   {{- $worker := resources.Get "search.js" | js.Build }}


### PR DESCRIPTION
This reverts commit c2c4b00119d40a628b1d4558528923a33a8d72cb to fix the build system. Once https://github.com/livingdocsIO/documentation/pull/929 is addressed, we can reapply this commit.