### PR TITLE
Replace opener with hugo built-in --openBrowser option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ You can run it locally:
 # install hugo
 brew install hugo
 
-# if you use WSL2 you need to additionaly install xdg-utils and setup a environment link to your prefered browser
-# you simply can skip this step and skip the opener by 
-sudo apt-get install -y xdg-utils
-
 # install dependencies
 npm install
 
@@ -21,17 +17,10 @@ npm install
 npm start
 ```
 
-If you use WSL2 and want to use opener (automatically starts the browser) you need to additionaly install xdg-utils and
-setup default browser (see below) OR skip this instructions, do not use the opener (npm start) and just start the server with 'exec hugo serve'
+If you use WSL2 and want a new browser window to open automatically when running the documentation locally, install `wslu`. You can find installation instructions in the [`wslu` documentation](https://wslutiliti.es/wslu/install.html). For example, on Ubuntu in WSL2, run:
+
 ```bash
-# install xdg-utils
-brew install hugo
-
-# link the default browser (opener can't handle blanks in paths)
-ln -s /mnt/c/path/to/browser.exe /path/to/symlink
-
-# define the default browser as variable
-export BROWSER=~/path/to/symlink
+sudo apt install wslu
 ```
 
 When working with the lunr search code it can be useful to test the real production setup, due to the way we edit the search index for production:

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "glob": "^11.0.0",
         "htmlparser2": "^9.0.0",
         "lunr": "^2.3.9",
-        "opener": "^1.5.2",
         "serve": "^14.2.0"
       }
     },
@@ -835,14 +834,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/opener": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
-      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
-      "bin": {
-        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/package-json-from-dist": {

--- a/package.json
+++ b/package.json
@@ -10,13 +10,12 @@
     "glob": "^11.0.0",
     "htmlparser2": "^9.0.0",
     "lunr": "^2.3.9",
-    "opener": "^1.5.2",
     "serve": "^14.2.0"
   },
   "scripts": {
     "build": "./bin/build.sh",
     "build:fast": "./bin/build.sh --fast",
-    "start": "opener http://localhost:1313 && exec hugo serve",
+    "start": "exec hugo server --buildDrafts --buildFuture --openBrowser",
     "start:production": "serve ./public"
   },
   "repository": {


### PR DESCRIPTION
Hugo v139.0 introduces a new `--optionBrowser` feature, which opens the project in the browser. This eliminates the need for the additional `opener` dependency. The browser window opens only after the page is built. Previously, starting the project would first open an empty page.
