### PR TITLE
Include `kordiam` server config

### DIFF
--- a/content/customising/server-configuration/_index.md
+++ b/content/customising/server-configuration/_index.md
@@ -1330,6 +1330,11 @@ There is a general `integrations` configuration for small integrations that can 
       allowed: true,
       ensureExtraction: true
     },
+    kordiam: {
+      allowed: true,
+      registerHooks: true,
+      forceLinkUsingKordiamApiRequest: false
+    },
     woodwingAssets: {
       allowed: true
     }


### PR DESCRIPTION
I realised the kordiam server configuration wasn't added in the documentation. We want to have all config properties documented.