### PR TITLE
fix(history button): Safari

### DIFF
--- a/themes/hugo-docs/assets/elements/history-button.scss
+++ b/themes/hugo-docs/assets/elements/history-button.scss
@@ -39,4 +39,8 @@
     overflow: hidden;
     border-left: 1px solid $color-grey-6;
   }
+
+  &::-webkit-details-marker {
+    display: none;
+  }
 }


### PR DESCRIPTION
- Hiding default arrow

# Screenshots
## Before
<img width="1087" alt="Bildschirmfoto 2025-02-03 um 09 19 00" src="https://github.com/user-attachments/assets/13e1fed6-a08e-4673-8ded-c3251ab82bd5" />




## After

<img width="1092" alt="Bildschirmfoto 2025-02-03 um 09 18 46" src="https://github.com/user-attachments/assets/39c6dafb-3f16-4a5f-b804-1923f288d183" />


