### PR TITLE
Update to correct values and versions

### DIFF
--- a/data/releases.json
+++ b/data/releases.json
@@ -15,13 +15,13 @@
     "key": "release-2025-03",
     "name": "March 2025",
     "ref": "/operations/releases/release-2025-03.md",
-    "upcoming": true,
-    "current": false,
-    "maintained": false,
+    "upcoming": false,
+    "current": true,
+    "maintained": true,
     "legacy": false,
     "sortId": 48,
-    "editorVersion": "v115.23.0",
-    "serverVersion": "v271.1.0"
+    "editorVersion": "v115.22.2",
+    "serverVersion": "v271.0.1"
   },
   "release-2025-01": {
     "key": "release-2025-01",


### PR DESCRIPTION
Ralph reported that we have an incorrect version in the releases.json: https://livingdocs.slack.com/archives/C4TGTEC3F/p1740551353043389?thread_ts=1740470994.998009&cid=C4TGTEC3F

I've updated them, along with the properties about maintainance etc.