### PR TITLE
fix: document usage of single quotes for secret-add value

### DIFF
--- a/content/guides/integrations/retresco.md
+++ b/content/guides/integrations/retresco.md
@@ -84,7 +84,7 @@ You will need to add the metadata plugin for all content types that you would li
 Finally, a secret must be added for the relevant `<project-handle>`. The `<secret-name>` should match the value of the `password.$secretRef.name` property in the Retresco integration's project config object. The `<password>` should be the password provided by Retresco used to access the API. Within a development or test environment it is also possible to seed this value.
 
 ```bash
-npx livingdocs-server secret-add --project="<project-handle>" --name="<secret-name>" --value="<password>"
+npx livingdocs-server secret-add --project="<project-handle>" --name="<secret-name>" --value='<password>'
 ```
 
 For more information on how to use secrets, please check [Project Secrets](../setup/project-secrets).

--- a/content/guides/setup/project-secrets.md
+++ b/content/guides/setup/project-secrets.md
@@ -13,7 +13,7 @@ This step requires having done the encryption keys setup, see [Initial Server Se
 To create the secret and update it to the Livingdocs Server's database use:
 
 ```bash
-$ livingdocs-server secret-add --project=handle --name=secretname --value=secretvalue -y
+$ livingdocs-server secret-add --project=handle --name=secretname --value='secretvalue' -y
 # We recommend using a standarized `secretName` to make management easier during operations, e.g. `secret-YYYY-MM`
 ```
 

--- a/content/reference/project-config/settings.md
+++ b/content/reference/project-config/settings.md
@@ -343,7 +343,7 @@ If you are using a seeding process, e.g. via the CLI then you need to manually g
 
 ```
 // NOTE: you need to choose a unique name, an easy way is to append the current date to the string 'imatrics-' as done below
-npx livingdocs-server secret-add --project=<handle> --name=imatrics-20211027 --value=secretvalue
+npx livingdocs-server secret-add --project=<handle> --name=imatrics-20211027 --value='secretvalue'
 // -> this adds a new secret 'imatrics-20211027' to our encrypted secret store
 ```
 


### PR DESCRIPTION
Relations:
  - Task: https://www.notion.so/livingdocsio/Replace-with-in-secret-add-command-173c559571d68047bf2bc5944b203f2d?pvs=4

# Motivation
The `value` argument in the `secret-add` command should be single-quoted, to prevent bash from potentially evaluating part of the value instead of treating it as a simple string.

# Changelog
- 🐞 Documentation: Use of single quotes for secret-add value
