### PR TITLE
Release Notes Cleanup for release-2025-05

### DIFF
--- a/content/operations/releases/release-2025-03.md
+++ b/content/operations/releases/release-2025-03.md
@@ -487,7 +487,7 @@ We are constantly patching module vulnerabilities for the Livingdocs Server and 
 This release we have patched the following vulnerabilities in the Livingdocs Server:
 
 - [CVE-2025-22150](https://github.com/advisories/GHSA-c76h-2ccp-4975) patched in `undici` v6.21.1
-- [CVE-2025-27152] patched in `axios` v1.8.2
+- [CVE-2025-27152](https://github.com/advisories/GHSA-jr5f-v2jv-69x6) patched in `axios` v1.8.2
 
 No known vulnerabilities. :tada:
 
@@ -496,7 +496,7 @@ No known vulnerabilities. :tada:
 This release we have patched the following vulnerabilities in the Livingdocs Editor:
 
 - [CVE-2025-22150](https://github.com/advisories/GHSA-c76h-2ccp-4975) patched in `undici` v6.21.1
-- [CVE-2025-27152] patched in `axios` v1.8.2
+- [CVE-2025-27152](https://github.com/advisories/GHSA-jr5f-v2jv-69x6) patched in `axios` v1.8.2
 
 We are aware of the following vulnerabilities in the Livingdocs Editor:
 

--- a/content/operations/releases/release-2025-03.md
+++ b/content/operations/releases/release-2025-03.md
@@ -488,6 +488,7 @@ This release we have patched the following vulnerabilities in the Livingdocs Ser
 
 - [CVE-2025-22150](https://github.com/advisories/GHSA-c76h-2ccp-4975) patched in `undici` v6.21.1
 - [CVE-2025-27152](https://github.com/advisories/GHSA-jr5f-v2jv-69x6) patched in `axios` v1.8.2
+- [CVE-2025-27789] https://github.com/advisories/GHSA-968p-4wvh-cqc8 patched `@babel/runtime` & `@babel/helpers` v7.26.10
 
 No known vulnerabilities. :tada:
 
@@ -497,6 +498,7 @@ This release we have patched the following vulnerabilities in the Livingdocs Edi
 
 - [CVE-2025-22150](https://github.com/advisories/GHSA-c76h-2ccp-4975) patched in `undici` v6.21.1
 - [CVE-2025-27152](https://github.com/advisories/GHSA-jr5f-v2jv-69x6) patched in `axios` v1.8.2
+- [CVE-2025-27789] https://github.com/advisories/GHSA-968p-4wvh-cqc8 patched `@babel/runtime` & `@babel/helpers` v7.26.10
 
 We are aware of the following vulnerabilities in the Livingdocs Editor:
 

--- a/content/operations/releases/release-2025-05.md
+++ b/content/operations/releases/release-2025-05.md
@@ -23,12 +23,14 @@ These are the release notes of the upcoming release (pull requests merged to the
 - :fire: Integration against the upcoming release (currently `master` branch) is at your own risk
 
 ## PRs to Categorize
+
 - [Bump minor version for release management](https://github.com/livingdocsIO/livingdocs-editor/pull/9891)
 - [Bump minor version for release management](https://github.com/livingdocsIO/livingdocs-server/pull/7978)
 - [Use correct document locale when selecting li-image metadata](https://github.com/livingdocsIO/livingdocs-editor/pull/9850)
 - [Display task deadline validation error for new tasks](https://github.com/livingdocsIO/livingdocs-editor/pull/9838)
 - [Add PEIQ agency report import flow](https://github.com/livingdocsIO/livingdocs-server/pull/7950)
 - [Fix `pqina` error in CI](https://github.com/livingdocsIO/livingdocs-editor/pull/9888)
+
 - [Add 2025-05 api version](https://github.com/livingdocsIO/livingdocs-server/pull/7974)
 - [fix(deps): update dependency pg from 8.15.5 to v8.15.6 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7973)
 - [First install NPM packages before embedding Pintura from node_modules](https://github.com/livingdocsIO/livingdocs-editor/pull/9883)
@@ -181,7 +183,6 @@ These are the release notes of the upcoming release (pull requests merged to the
 - [Keep support for beta routes](https://github.com/livingdocsIO/livingdocs-server/pull/7759)
 - [Fix opening document inbox when in visibility mode](https://github.com/livingdocsIO/livingdocs-editor/pull/9610)
 
-
 To get an overview about new functionality, read the [Release Notes](TODO).
 To learn about the necessary actions to update Livingdocs to `release-2025-05`, read on.
 
@@ -214,7 +215,7 @@ To learn about the necessary actions to update Livingdocs to `release-2025-05`, 
 
 | Name                           | Version                                                                                  |
 | ------------------------------ | ---------------------------------------------------------------------------------------- |
-| Node                           | 20.18                                                                                    |
+| Node                           | 20.19                                                                                    |
 | NPM                            | 10                                                                                       |
 | Postgres                       | 13                                                                                       |
 | Elasticsearch<br/>OpenSearch   | 7.x<br/>1                                                                                |
@@ -223,22 +224,47 @@ To learn about the necessary actions to update Livingdocs to `release-2025-05`, 
 | Livingdocs Editor Docker Image | livingdocs/editor-base:20:7                                                              |
 | Browser Support                | Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78 |
 
+## Deployment
+
+TODO: check migrations / add deployment steps as in release-2025-03
+
 ## Breaking Changes 🔥
 
-{{< feature-info "Operations" "server" >}}
+### Update Minimal Node Version v20.19 :fire:
 
-### Migrate the Postgres Database :fire:
+The minimal supported Node.js version is now `v20.19.0`.
+This version allows us to require esm modules within commonjs.
 
-It's a simple/fast migration with no expected data losses.
+### Rebrand of Desk-Net to Kordiam :fire:
 
-```sh
-# run `livingdocs-server migrate up` to update to the newest database schema
-livingdocs-server migrate up
-```
+Desk-Net rebranded as Kordiam.
+To align Livingdocs with this change, we previously introduced corresponding Kordiam properties, features, and plugins.
+With this release, we are removing the superseded Desk-Net functionality:
 
-TODO: check migration
+- Feature `li-desknet` and `li-desknet-`integration, including all server APIs
+- Server config `desknet`, `integrations.desknet`, and `hugo.print.desknetMetadataFields`
+- Project config `settings.desknet`, `settings.integrations.desknet`, and `contentTypes.[*].desknet`
+- Function parameter `desknetApi` of Desk-Net/Kordiam functions
+- `desknet` property in the return objects of `projectApi.getProject()` and `systemApi.config()`
+- Metadata plugins `li-desknet-global`, `li-desknet-integration`, and `li-desknet-schedule`
+- li-kordiam-schedule config property `desknetExternalElementIdMetadataPath`
+
+### Removal of Menu Tool :fire:
+
+The Menu Tool has been removed.
+
+- Menu items `{liItem: 'menus'}` are no longer supported. Please remove them from the project config.
+- Public API GET `/api/:apiVersion/menus/:channelHandle?` has been removed.
+- Feature `li-menus` has been removed including all its server APIs.
+
+### Removal of config.contentTypes :fire:
+
+The deprecated shorthand property `config.contentTypes` in the li-document-search metadata plugin was now removed.
+Use `config.contentType` instead.
 
 ## Deprecations
+
+TODO: no deprecations, just removals??
 
 ## Features
 
@@ -269,10 +295,12 @@ The effect will go away automatically after a certain time.
      ]
    }
    ```
+
    - **handle**: Make sure to use the same handle for all content types where the plugin is configured
    - **indexing**: The config option `index` needs to be enabled for it to work
 
 2. Generally allow exposure boosting for certain teasers in their service params schema
+
    ```js
    {
      name: 'someTeaserService',
@@ -314,6 +342,29 @@ The effect will go away automatically after a certain time.
 
 Visit the [`li-exposure-boost` plugin]({{< ref "/reference/document/metadata/plugins/li-exposure-boost" >}}) page for more information.
 
+{{< feature-info "" "" >}}
+
+### Document Inbox for Data Records :gift:
+
+{{< feature-info "" "" >}}
+
+### Media Center Image Editing :gift:
+
+{{< feature-info "" "" >}}
+
+### PEIQ Integration - Article Import :gift:
+
+{{< feature-info "" "" >}}
+
+### Media Center - Delete language metadata set :gift:
+
+{{< feature-info "" "" >}}
+
+### Table Dashboards - Support All Metadata Cells :gift:
+
+{{< feature-info "" "" >}}
+
+### Additional oEmbed Providers :gift:
 
 ## Vulnerability Patches
 
@@ -323,7 +374,7 @@ We are constantly patching module vulnerabilities for the Livingdocs Server and 
 
 This release we have patched the following vulnerabilities in the Livingdocs Server:
 
-- TBD
+- TODO: add
 
 No known vulnerabilities. :tada:
 
@@ -331,7 +382,7 @@ No known vulnerabilities. :tada:
 
 This release we have patched the following vulnerabilities in the Livingdocs Editor:
 
-- TBD
+- TODO: add
 
 We are aware of the following vulnerabilities in the Livingdocs Editor:
 
@@ -343,10 +394,12 @@ We are aware of the following vulnerabilities in the Livingdocs Editor:
 Here is a list of all patches after the release has been announced.
 
 ### Livingdocs Server Patches
+
 - [v276.3.2](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v276.3.2): fix(data-migration-run): Parse argument --filter-by-id to integers
 - [v276.3.1](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v276.3.1): fix(peiq-agency): Improve handling of empty property image_ids
 
 ### Livingdocs Editor Patches
+
 - [v117.6.4](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v117.6.4): fix(drag-drop): Clear up markers after dragend event
 - [v117.6.3](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v117.6.3): fix(core): Replace app when registering project settings components
 - [v117.6.2](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v117.6.2): fix(properties-panel): Hide edit local version when empty

--- a/content/operations/releases/release-2025-05.md
+++ b/content/operations/releases/release-2025-05.md
@@ -240,8 +240,6 @@ Here is a list of all patches after the release has been announced.
 
 ### Livingdocs Server Patches
 
-- [v117.6.3](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v117.6.3): fix(core): Replace app when registering project settings components
-- [v117.6.2](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v117.6.2): fix(properties-panel): Hide edit local version when empty
 - [v276.3.2](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v276.3.2): fix(data-migration-run): Parse argument --filter-by-id to integers
 - [v276.3.1](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v276.3.1): fix(peiq-agency): Improve handling of empty property image_ids
 

--- a/content/operations/releases/release-2025-05.md
+++ b/content/operations/releases/release-2025-05.md
@@ -217,7 +217,8 @@ We are constantly patching module vulnerabilities for the Livingdocs Server and 
 
 This release we have patched the following vulnerabilities in the Livingdocs Server:
 
-- TODO: add
+- [CVE-2025-32442](https://github.com/fastify/fastify/security/advisories/GHSA-mg2h-6x62-wpwc) patched in `fastify` v5.3.2
+- [CVE-2025-27789] https://github.com/advisories/GHSA-968p-4wvh-cqc8 patched `@babel/runtime` & `@babel/helpers` v7.26.10
 
 No known vulnerabilities. :tada:
 
@@ -225,7 +226,8 @@ No known vulnerabilities. :tada:
 
 This release we have patched the following vulnerabilities in the Livingdocs Editor:
 
-- TODO: add
+- [CVE-2025-32442](https://github.com/fastify/fastify/security/advisories/GHSA-mg2h-6x62-wpwc) patched in `fastify` v5.3.2
+- [CVE-2025-27789] https://github.com/advisories/GHSA-968p-4wvh-cqc8 patched `@babel/runtime` & `@babel/helpers` v7.26.10
 
 We are aware of the following vulnerabilities in the Livingdocs Editor:
 

--- a/content/operations/releases/release-2025-05.md
+++ b/content/operations/releases/release-2025-05.md
@@ -13,16 +13,8 @@ header:
   branchHandle: release-2025-05
 ---
 
-## Caveat :fire:
-
-These are the release notes of the upcoming release (pull requests merged to the main branch).
-
-- :information_source: this document is updated automatically by a bot (pr's to categorize section)
-- :information_source: this document will be roughly updated manually once a week (put PRs + description to the right section)
-- :fire: We don't guarantee stable APIs. They can still change until the official release
-- :fire: Integration against the upcoming release (currently `master` branch) is at your own risk
-
-## PRs to Categorize
+To get an overview about new functionality, read the [Release Notes] (TODO: add release notes when finished).
+To learn about the necessary actions to update Livingdocs to `release-2025-05`, read on.
 
 - [Bump minor version for release management](https://github.com/livingdocsIO/livingdocs-editor/pull/9891)
 - [Bump minor version for release management](https://github.com/livingdocsIO/livingdocs-server/pull/7978)
@@ -30,161 +22,6 @@ These are the release notes of the upcoming release (pull requests merged to the
 - [Display task deadline validation error for new tasks](https://github.com/livingdocsIO/livingdocs-editor/pull/9838)
 - [Add PEIQ agency report import flow](https://github.com/livingdocsIO/livingdocs-server/pull/7950)
 - [Fix `pqina` error in CI](https://github.com/livingdocsIO/livingdocs-editor/pull/9888)
-
-- [Add 2025-05 api version](https://github.com/livingdocsIO/livingdocs-server/pull/7974)
-- [fix(deps): update dependency pg from 8.15.5 to v8.15.6 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7973)
-- [First install NPM packages before embedding Pintura from node_modules](https://github.com/livingdocsIO/livingdocs-editor/pull/9883)
-- [Image editing](https://github.com/livingdocsIO/livingdocs-server/pull/7886)
-- [fix(deps): update dependency @smithy/signature-v4 from 5.0.2 to v5.1.0 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7963)
-- [fix(deps): update dependency pg from 8.15.1 to v8.15.5 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7961)
-- [Make li-image upload state reactive](https://github.com/livingdocsIO/livingdocs-editor/pull/9859)
-- [fix(deps): update dependency sass from 1.86.3 to v1.87.0 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9875)
-- [fix(deps): update dependency @azure/identity from 4.8.0 to v4.9.1 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7938)
-- [fix(deps): update dependency @livingdocs/framework from 32.7.5 to v32.7.6 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9872)
-- [fix(deps): update dependency cypress from 14.3.1 to v14.3.2 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9876)
-- [fix(deps): update dependency @livingdocs/framework from 32.7.4 to v32.7.6 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7956)
-- [Do not rely on config within cli option building](https://github.com/livingdocsIO/livingdocs-server/pull/7951)
-- [Fix issue where leaving selection mode would occasionally not re-enable the interactive view](https://github.com/livingdocsIO/livingdocs-editor/pull/9846)
-- [Allow deletion of media library entry translations](https://github.com/livingdocsIO/livingdocs-editor/pull/9826)
-- [Reset replaced state when picking new media](https://github.com/livingdocsIO/livingdocs-editor/pull/9840)
-- [Apply media library filters from URL on browser reload](https://github.com/livingdocsIO/livingdocs-editor/pull/9837)
-- [fix(deps): update dependency @livingdocs/framework from 32.7.4 to v32.7.5 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9860)
-- [Allow string for comment component indicator label](https://github.com/livingdocsIO/livingdocs-editor/pull/9845)
-- [Update media titles and actions in properties panel on media change](https://github.com/livingdocsIO/livingdocs-editor/pull/9847)
-- [Flush autosave on media library detail view close](https://github.com/livingdocsIO/livingdocs-editor/pull/9843)
-- [fix(deps): update dependency webpack from 5.99.5 to v5.99.6 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9842)
-- [fix(deps): update dependency fastify from 5.3.1 to 5.3.2 [security] (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9841)
-- [chore(deps): update dependency eslint from 9.24.0 to v9.25.0 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7946)
-- [fix(deps): update dependency fastify from 5.3.0 to 5.3.1 [security] (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7944)
-- [fix(deps): update dependency fastify from 5.3.0 to 5.3.1 [security] (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9839)
-- [Add parameters concurrency and batchSize to change-design-name-and-version-to-latest-project-design CLI](https://github.com/livingdocsIO/livingdocs-server/pull/7940)
-- [fix(deps): update dependency open from 10.1.0 to v10.1.1 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9832)
-- [fix(deps): update dependency posthog-node from 4.11.6 to v4.11.7 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7937)
-- [Allow deletion of media library entry translations in mediaLibraryApi.update()](https://github.com/livingdocsIO/livingdocs-server/pull/7926)
-- [Add CLI task change-design-name-and-version-to-latest-project-design](https://github.com/livingdocsIO/livingdocs-server/pull/7929)
-- [Require Facebook credentials when all oEmbed providers are loaded](https://github.com/livingdocsIO/livingdocs-server/pull/7917)
-- [Optimize data migration database query](https://github.com/livingdocsIO/livingdocs-server/pull/7933)
-- [Migrate Angular comment-wrapper component to Vue](https://github.com/livingdocsIO/livingdocs-editor/pull/9755)
-- [Add Bluesky, Pinterest and Reddit oEmbed providers](https://github.com/livingdocsIO/livingdocs-server/pull/7916)
-- [implement `li-button-confirm` with floating-ui library](https://github.com/livingdocsIO/livingdocs-editor/pull/9804)
-- [Adjust exposure boost durations](https://github.com/livingdocsIO/livingdocs-server/pull/7931)
-- [fix(deps): update dependency posthog-node from 4.11.3 to v4.11.6 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7932)
-- [Feat/li Button Concept](https://github.com/livingdocsIO/livingdocs-editor/pull/9810)
-- [Remove `config.contentTypes` from `li-document-search`](https://github.com/livingdocsIO/livingdocs-server/pull/7930)
-- [fix(deps): update dependency mime from 4.0.6 to v4.0.7 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7888)
-- [fix(deps): update dependency fastify from 5.2.2 to v5.3.0 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7928)
-- [fix(deps): update dependency fastify from 5.2.2 to v5.3.0 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9828)
-- [fix(deps): update dependency nodemailer from 6.10.0 to v6.10.1 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7927)
-- [fix(deps): update dependency posthog-node from 4.11.2 to v4.11.3 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7920)
-- [fix(deps): update dependency jose from 5.10.0 to v6 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7749)
-- [fix(deps): update dependency chartist from 1.3.0 to v1.3.1 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9792)
-- [Fix/li-card Body Height](https://github.com/livingdocsIO/livingdocs-editor/pull/9817)
-- [fix(deps): update dependency express from 5.0.1 to v5.1.0 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7890)
-- [Set image default width on image directive if present](https://github.com/livingdocsIO/livingdocs-editor/pull/9813)
-- [Fix distribution date in non-planning-boards](https://github.com/livingdocsIO/livingdocs-editor/pull/9802)
-- [Make design in document revision optional](https://github.com/livingdocsIO/livingdocs-server/pull/7904)
-- [Reload document when only document design changed](https://github.com/livingdocsIO/livingdocs-editor/pull/9800)
-- [Improvement/Metadata View Layout](https://github.com/livingdocsIO/livingdocs-editor/pull/9798)
-- [Fix/Assistant Busy Button](https://github.com/livingdocsIO/livingdocs-editor/pull/9797)
-- [Fix GIF image upload with use2025behavior](https://github.com/livingdocsIO/livingdocs-server/pull/7887)
-- [fix(deps): update dependency posthog-node from 4.11.1 to v4.11.2 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7901)
-- [Restrict distinct query of delivery status to project & document scope](https://github.com/livingdocsIO/livingdocs-server/pull/7897)
-- [chore(deps): update dependency eslint from 9.23.0 to v9.24.0 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9790)
-- [Remove mapping of desknet properties in projectProxy and systemProxy](https://github.com/livingdocsIO/livingdocs-editor/pull/9724)
-- [Remove Desk-Net properties, features, and plugins](https://github.com/livingdocsIO/livingdocs-server/pull/7844)
-- [Feat: add missing cells to table dashboard](https://github.com/livingdocsIO/livingdocs-editor/pull/9772)
-- [Only render the document preview after the iframe load event fires to prevent flickers](https://github.com/livingdocsIO/livingdocs-editor/pull/9779)
-- [Prevent token and user stats consumer deadlocks in postgres](https://github.com/livingdocsIO/livingdocs-server/pull/7892)
-- [fix(deps): update dependency sass from 1.86.2 to v1.86.3 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9787)
-- [fix(li-form-textarea): non-editable state](https://github.com/livingdocsIO/livingdocs-editor/pull/9785)
-- [Allow configuring `alt` in shortcuts](https://github.com/livingdocsIO/livingdocs-editor/pull/9773)
-- [fix(deps): update aws-sdk (main) (minor)](https://github.com/livingdocsIO/livingdocs-server/pull/7875)
-- [Prevent text-info-settings from blocking text selection](https://github.com/livingdocsIO/livingdocs-editor/pull/9778)
-- [Remove unused @forward declarations in sass](https://github.com/livingdocsIO/livingdocs-editor/pull/9775)
-- [Upgrade to node v20.19](https://github.com/livingdocsIO/livingdocs-server/pull/7883)
-- [Migrate Angular comment-thread component to Vue](https://github.com/livingdocsIO/livingdocs-editor/pull/9742)
-- [Feat: clickable titles in teaser sidebar](https://github.com/livingdocsIO/livingdocs-editor/pull/9744)
-- [improvement(visited document highlight): Animation added](https://github.com/livingdocsIO/livingdocs-editor/pull/9771)
-- [Chore/small icon size corrections](https://github.com/livingdocsIO/livingdocs-editor/pull/9768)
-- [fix(manual document status): Empty state](https://github.com/livingdocsIO/livingdocs-editor/pull/9763)
-- [Migrate Angular li-comment component to Vue](https://github.com/livingdocsIO/livingdocs-editor/pull/9721)
-- [fix(deps): update dependency posthog-node from 4.10.1 to v4.10.2 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7879)
-- [fix(deps): update dependency fastify from 5.2.1 to v5.2.2 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7878)
-- [fix(deps): update dependency fastify from 5.2.1 to v5.2.2 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9762)
-- [fix(deps): update aws-sdk (main) (patch)](https://github.com/livingdocsIO/livingdocs-server/pull/7874)
-- [Apply crops in top left corner of an image](https://github.com/livingdocsIO/livingdocs-server/pull/7869)
-- [Show content type label instead of content type handle in li-document-resource component](https://github.com/livingdocsIO/livingdocs-editor/pull/9749)
-- [chore(deps): update dependency eslint from 9.22.0 to v9.23.0 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9754)
-- [Check entry exists before displaying stored in archive icon in the media library card component](https://github.com/livingdocsIO/livingdocs-editor/pull/9750)
-- [fix(deps): update aws-sdk from 3.758.0 to v3.772.0 (main) (minor)](https://github.com/livingdocsIO/livingdocs-server/pull/7863)
-- [fix(deps): update dependency @livingdocs/framework from 32.7.2 to v32.7.3 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9747)
-- [fix(deps): update dependency @livingdocs/framework from 32.7.2 to v32.7.3 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7864)
-- [Fix: clipboard use first descendant with content for description](https://github.com/livingdocsIO/livingdocs-editor/pull/9741)
-- [fix(deps): update dependency axios from 1.8.3 to v1.8.4 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9745)
-- [fix(deps): update dependency axios from 1.8.3 to v1.8.4 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7860)
-- [Improvement/Example Server Design](https://github.com/livingdocsIO/livingdocs-server/pull/7847)
-- [Fix: add cloudinary storage for image variants](https://github.com/livingdocsIO/livingdocs-server/pull/7762)
-- [fix(deps): update playwright monorepo from 1.51.0 to v1.51.1 (main) (patch)](https://github.com/livingdocsIO/livingdocs-editor/pull/9739)
-- [fix(deps): update dependency pg from 8.14.0 to v8.14.1 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7851)
-- [Fix: peiq check externalid on image drop](https://github.com/livingdocsIO/livingdocs-editor/pull/9684)
-- [fix: document usage of single quotes for secret-add value](https://github.com/livingdocsIO/livingdocs-server/pull/7848)
-- [fix(deps): update dependency @livingdocs/framework from 32.7.1 to v32.7.2 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7846)
-- [fix(deps): update dependency @livingdocs/framework from 32.7.1 to v32.7.2 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9734)
-- [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-editor/pull/9733)
-- [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-server/pull/7845)
-- [Add li-kordiam-integration to supported dashboard columns](https://github.com/livingdocsIO/livingdocs-editor/pull/9728)
-- [Make document dashboard toolbar action button active state reactive](https://github.com/livingdocsIO/livingdocs-editor/pull/9718)
-- [fix(li-button--bar): Long labels](https://github.com/livingdocsIO/livingdocs-editor/pull/9722)
-- [Show image for current locale in media library lightbox](https://github.com/livingdocsIO/livingdocs-editor/pull/9719)
-- [Remove Menu Tool](https://github.com/livingdocsIO/livingdocs-server/pull/7838)
-- [Remove Menu Tool](https://github.com/livingdocsIO/livingdocs-editor/pull/9714)
-- [feat: migrate comment header from angular to vue](https://github.com/livingdocsIO/livingdocs-editor/pull/9713)
-- [fix(deps): update dependency axios from 1.8.2 to v1.8.3 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9716)
-- [fix(deps): update dependency @babel/core from 7.26.9 to v7.26.10 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9711)
-- [Show more than 100 revisions in history](https://github.com/livingdocsIO/livingdocs-server/pull/7830)
-- [Ignore the legacy revision.data.layout property that prevents diffing history entries on content type change](https://github.com/livingdocsIO/livingdocs-editor/pull/9670)
-- [Save field extractor changes after assistant finished](https://github.com/livingdocsIO/livingdocs-editor/pull/9673)
-- [fix(deps): update dependency @livingdocs/framework from 32.7.0 to v32.7.1 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7829)
-- [fix(deps): update dependency @livingdocs/framework from 32.7.0 to v32.7.1 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9699)
-- [Do not try to serialize streams in pino serializer for axios](https://github.com/livingdocsIO/livingdocs-server/pull/7821)
-- [Fix: peiq add externalid and systemname to elasticsearch](https://github.com/livingdocsIO/livingdocs-server/pull/7796)
-- [No longer allow videos and files in inbox](https://github.com/livingdocsIO/livingdocs-server/pull/7811)
-- [Omit devDependencies from npm-shrinkwrap.json](https://github.com/livingdocsIO/livingdocs-server/pull/7813)
-- [Account for migratedDocumentVersionDelta when component condition is triggered](https://github.com/livingdocsIO/livingdocs-server/pull/7814)
-- [Fix: rename url path to serve-image instead of serve-images](https://github.com/livingdocsIO/livingdocs-editor/pull/9690)
-- [Fix: rename url path to serve-image instead of serve-images](https://github.com/livingdocsIO/livingdocs-server/pull/7808)
-- [Add tests for version 2025-03 of /latestPublication](https://github.com/livingdocsIO/livingdocs-server/pull/7801)
-- [fix(deps): update dependency axios from 1.7.9 to 1.8.2 [security] (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/9687)
-- [Throw LIBREAKING038 and LIBREAKING039 messages](https://github.com/livingdocsIO/livingdocs-server/pull/7797)
-- [Fix creation flow warning](https://github.com/livingdocsIO/livingdocs-editor/pull/9678)
-- [Fix distribution dates](https://github.com/livingdocsIO/livingdocs-editor/pull/9679)
-- [Open documents from task screen with task panel open](https://github.com/livingdocsIO/livingdocs-editor/pull/9674)
-- [Clear authorization middleware cache on api client token or user session change](https://github.com/livingdocsIO/livingdocs-server/pull/7793)
-- [Fix: peiq do metadata extraction when replacing an image](https://github.com/livingdocsIO/livingdocs-editor/pull/9666)
-- [fix(media library): detail details](https://github.com/livingdocsIO/livingdocs-editor/pull/9635)
-- [fix(deps): update dependency @livingdocs/framework from 32.6.2 to v32.7.0 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7756)
-- [Fix positioning for named crops in portrait mode](https://github.com/livingdocsIO/livingdocs-editor/pull/9662)
-- [Fix Editor Scrolling](https://github.com/livingdocsIO/livingdocs-editor/pull/9660)
-- [fix(deps): update dependency exifreader from 4.26.1 to v4.26.2 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/7789)
-- [Use Print instead of Druck for german print version labels](https://github.com/livingdocsIO/livingdocs-editor/pull/9649)
-- [Trackjs Sanitization](https://github.com/livingdocsIO/livingdocs-editor/pull/9644)
-- [fix(distribution dates): Polish](https://github.com/livingdocsIO/livingdocs-editor/pull/9647)
-- [Fix: image-variants pass strip path prefix ](https://github.com/livingdocsIO/livingdocs-editor/pull/9630)
-- [Prevent notification composition failure when no modes are defined](https://github.com/livingdocsIO/livingdocs-server/pull/7782)
-- [Account for migratedDocumentVersionDelta when setting model version after an update](https://github.com/livingdocsIO/livingdocs-server/pull/7778)
-- [Only show "Store in Archive" when `use2025Behavior: true`](https://github.com/livingdocsIO/livingdocs-editor/pull/9622)
-- [Fix: azure storage not handling 404 correctly](https://github.com/livingdocsIO/livingdocs-server/pull/7775)
-- [Rename media library config option preserveOriginalAssets to use2025Behavior (Part II)](https://github.com/livingdocsIO/livingdocs-editor/pull/9638)
-- [Prevent serving invalid images from Public API](https://github.com/livingdocsIO/livingdocs-server/pull/7758)
-- [Do not focus component when mentioning user in comment](https://github.com/livingdocsIO/livingdocs-editor/pull/9617)
-- [Do not let format popover slip behind preview panel](https://github.com/livingdocsIO/livingdocs-editor/pull/9623)
-- [Fix/media library footer width](https://github.com/livingdocsIO/livingdocs-editor/pull/9597)
-- [Make webhook timeout configurable](https://github.com/livingdocsIO/livingdocs-server/pull/7764)
-- [Keep support for beta routes](https://github.com/livingdocsIO/livingdocs-server/pull/7759)
-- [Fix opening document inbox when in visibility mode](https://github.com/livingdocsIO/livingdocs-editor/pull/9610)
-
-To get an overview about new functionality, read the [Release Notes](TODO).
-To learn about the necessary actions to update Livingdocs to `release-2025-05`, read on.
 
 **Attention:** If you skipped one or more releases, please also check the release-notes of the skipped ones.
 
@@ -224,16 +61,16 @@ To learn about the necessary actions to update Livingdocs to `release-2025-05`, 
 | Livingdocs Editor Docker Image | livingdocs/editor-base:20:7                                                              |
 | Browser Support                | Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78 |
 
-## Deployment
-
-TODO: check migrations / add deployment steps as in release-2025-03
-
 ## Breaking Changes 🔥
+
+{{< feature-info "" "" >}}
 
 ### Update Minimal Node Version v20.19 :fire:
 
 The minimal supported Node.js version is now `v20.19.0`.
 This version allows us to require esm modules within commonjs.
+
+{{< feature-info "" "" >}}
 
 ### Rebrand of Desk-Net to Kordiam :fire:
 
@@ -249,6 +86,8 @@ With this release, we are removing the superseded Desk-Net functionality:
 - Metadata plugins `li-desknet-global`, `li-desknet-integration`, and `li-desknet-schedule`
 - li-kordiam-schedule config property `desknetExternalElementIdMetadataPath`
 
+{{< feature-info "" "" >}}
+
 ### Removal of Menu Tool :fire:
 
 The Menu Tool has been removed.
@@ -257,6 +96,8 @@ The Menu Tool has been removed.
 - Public API GET `/api/:apiVersion/menus/:channelHandle?` has been removed.
 - Feature `li-menus` has been removed including all its server APIs.
 
+{{< feature-info "" "" >}}
+
 ### Removal of config.contentTypes :fire:
 
 The deprecated shorthand property `config.contentTypes` in the li-document-search metadata plugin was now removed.
@@ -264,7 +105,7 @@ Use `config.contentType` instead.
 
 ## Deprecations
 
-TODO: no deprecations, just removals??
+There have been no deprecations since the last release.
 
 ## Features
 
@@ -366,6 +207,14 @@ Visit the [`li-exposure-boost` plugin]({{< ref "/reference/document/metadata/plu
 
 ### Additional oEmbed Providers :gift:
 
+{{< feature-info "" "" >}}
+
+### Added Clipboard Context
+
+{{< feature-info "" "" >}}
+
+### Clickable Titles in Teaser Sidebar
+
 ## Vulnerability Patches
 
 We are constantly patching module vulnerabilities for the Livingdocs Server and Livingdocs Editor as module fixes are available. Below is a list of all patched vulnerabilities included in the release.
@@ -395,6 +244,8 @@ Here is a list of all patches after the release has been announced.
 
 ### Livingdocs Server Patches
 
+- [v117.6.3](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v117.6.3): fix(core): Replace app when registering project settings components
+- [v117.6.2](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v117.6.2): fix(properties-panel): Hide edit local version when empty
 - [v276.3.2](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v276.3.2): fix(data-migration-run): Parse argument --filter-by-id to integers
 - [v276.3.1](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v276.3.1): fix(peiq-agency): Improve handling of empty property image_ids
 

--- a/content/operations/releases/release-2025-05.md
+++ b/content/operations/releases/release-2025-05.md
@@ -16,13 +16,6 @@ header:
 To get an overview about new functionality, read the [Release Notes] (TODO: add release notes when finished).
 To learn about the necessary actions to update Livingdocs to `release-2025-05`, read on.
 
-- [Bump minor version for release management](https://github.com/livingdocsIO/livingdocs-editor/pull/9891)
-- [Bump minor version for release management](https://github.com/livingdocsIO/livingdocs-server/pull/7978)
-- [Use correct document locale when selecting li-image metadata](https://github.com/livingdocsIO/livingdocs-editor/pull/9850)
-- [Display task deadline validation error for new tasks](https://github.com/livingdocsIO/livingdocs-editor/pull/9838)
-- [Add PEIQ agency report import flow](https://github.com/livingdocsIO/livingdocs-server/pull/7950)
-- [Fix `pqina` error in CI](https://github.com/livingdocsIO/livingdocs-editor/pull/9888)
-
 **Attention:** If you skipped one or more releases, please also check the release-notes of the skipped ones.
 
 ## Webinar

--- a/content/operations/releases/release-2025-05.md
+++ b/content/operations/releases/release-2025-05.md
@@ -56,16 +56,16 @@ To learn about the necessary actions to update Livingdocs to `release-2025-05`, 
 
 ## Breaking Changes 🔥
 
-{{< feature-info "" "" >}}
+{{< feature-info "Dependencies" "Version" >}}
 
 ### Update Minimal Node Version v20.19 :fire:
 
 The minimal supported Node.js version is now `v20.19.0`.
 This version allows us to require esm modules within commonjs.
 
-{{< feature-info "" "" >}}
+{{< feature-info "Server" "Removal" >}}
 
-### Rebrand of Desk-Net to Kordiam :fire:
+### Removal of Desk-Net in favor to Kordiam :fire:
 
 Desk-Net rebranded as Kordiam.
 To align Livingdocs with this change, we previously introduced corresponding Kordiam properties, features, and plugins.
@@ -78,8 +78,9 @@ With this release, we are removing the superseded Desk-Net functionality:
 - `desknet` property in the return objects of `projectApi.getProject()` and `systemApi.config()`
 - Metadata plugins `li-desknet-global`, `li-desknet-integration`, and `li-desknet-schedule`
 - li-kordiam-schedule config property `desknetExternalElementIdMetadataPath`
+- TODO: @marcbachmann -> API urls changes?
 
-{{< feature-info "" "" >}}
+{{< feature-info "Server" "Removal" >}}
 
 ### Removal of Menu Tool :fire:
 
@@ -89,7 +90,7 @@ The Menu Tool has been removed.
 - Public API GET `/api/:apiVersion/menus/:channelHandle?` has been removed.
 - Feature `li-menus` has been removed including all its server APIs.
 
-{{< feature-info "" "" >}}
+{{< feature-info "Server" "Removal" >}}
 
 ### Removal of config.contentTypes :fire:
 


### PR DESCRIPTION
## Motivation
New release needs the technical release notes to be cleaned up.

## Changelog & Info
- Remove PRs to categorize after checking them
- Don't add `Deployment` section, as in release-2025-03, as we don't have migrations this cycle
- Added features and breaking change bullet points
- Added vulnerability patches (to release-05 and release-03)
