### PR TITLE
Add separate openApi page with links to all OpenAPI JSON files

### DIFF
--- a/content/reference/public-api/_index.md
+++ b/content/reference/public-api/_index.md
@@ -6,18 +6,6 @@ renderTOC: false
 weight: 1
 ---
 
-## OpenAPI
-
-The [Livingdocs Public API]({{< ref "/reference/public-api" >}}) can be tested and consumed with an [OpenAPI v3 specification file]({{< openapi "/openapi.json" >}}).
-
-Thanks to the [OpenAPI specification](https://spec.openapis.org/oas/v3.1.0.html), it's possible to quickly test the API using [Swagger UI](https://editor-next.swagger.io/?url={{< openapi "/openapi.json" >}}). And import the full collection of existing API endpoints into Insomnia or Postman.
-
-The easiest way to import the endpoint collection is from a URL, both Postman and Insomnia support it.
-
-```
-{{< openapi "/openapi.json" >}}
-```
-
 ## Video Guide
 
 Quick tour how to read the public API documentation and how to use the public API to query documents from Livingdocs.

--- a/content/reference/public-api/open-api.md
+++ b/content/reference/public-api/open-api.md
@@ -1,0 +1,23 @@
+---
+title: Open API
+weight: 1
+# renderTOC: false
+menus: public-api
+---
+
+## OpenAPI
+
+The [Livingdocs Public API]({{< ref "/reference/public-api" >}}) can be tested and consumed with an [OpenAPI v3 specification file]({{< openapi "/openapi.json" >}}).
+
+Thanks to the [OpenAPI specification](https://spec.openapis.org/oas/v3.1.0.html), it's possible to quickly test the API using [Swagger UI](https://editor-next.swagger.io/?url={{< openapi "/openapi.json" >}}). And import the full collection of existing API endpoints into Insomnia or Postman.
+
+The easiest way to import the current endpoint collection is from a URL, both Postman and Insomnia support it.
+
+```
+{{< openapi "/openapi.json" >}}
+```
+
+## Release specific versions
+
+All available Versions:
+{{< openapi-list >}}

--- a/themes/hugo-docs/layouts/shortcodes/openapi-list.html
+++ b/themes/hugo-docs/layouts/shortcodes/openapi-list.html
@@ -1,0 +1,10 @@
+{{- $versions := hugo.Store.Get "api-versions" -}}
+{{- range $versions -}}
+  <!-- Sideeffect: publish json file at path /openapi-version.json -->
+  {{ $resource := (resources.FromString (printf "openapi-%s.json" .version) (partialCached "openapi-template.gotmpl" (dict "Site" $.Site "version" .version) .version)) -}}
+  {{ $resource.Publish }}
+  <p>
+    <strong>{{ .version }}:</strong><br />
+    <a href="{{ $resource.Permalink }}">{{ $resource.Permalink }}</a>
+  </p>
+{{- end -}}

--- a/themes/hugo-docs/layouts/shortcodes/openapi.html
+++ b/themes/hugo-docs/layouts/shortcodes/openapi.html
@@ -1,8 +1,11 @@
 {{- $versions := hugo.Store.Get "api-versions" -}}
-{{- $firstVersion := index $versions 0 -}}
-{{- range $versions -}}
-  {{ (resources.FromString (printf "openapi-%s.json" .version) (partialCached "openapi-template.gotmpl" (dict "Site" $.Site "version" .version) .version)).Publish }}
-{{- end -}}
-{{- $latest := (resources.FromString "openapi.json" (partialCached "openapi-template.gotmpl" (dict "Site" $.Site "version" $firstVersion.version) $firstVersion.version)) -}}
-{{- $latest.Publish -}}
-{{- $latest.Permalink -}}
+
+
+<!-- Note: $version will have upcoming versions excluded if buildDrafts is false (see partial _api-versions.html) -->
+{{- $currentVersion := index $versions 0 -}}
+
+
+<!-- Sideeffect: publish json file at path /openapi.json -->
+{{- $current := (resources.FromString "openapi.json" (partialCached "openapi-template.gotmpl" (dict "Site" $.Site "version" $currentVersion.version) $currentVersion.version)) -}}
+{{- $current.Publish -}}
+{{- $current.Permalink -}}


### PR DESCRIPTION
# Changelog

- Add a separate Open API page for the public API docs that is easier to find
- Add a list of all version specific Open API JSON documents