### PR TITLE
Add breaking change release-2025-05

### DIFF
--- a/content/customising/server/server-api/data-source-api.md
+++ b/content/customising/server/server-api/data-source-api.md
@@ -46,7 +46,6 @@ liServer.registerInitializedHook(() => {
      * @param {Number} params.projectId
      * @param {Number} params.userId
      * @param {Object} params.params params will be passed by the requester
-     *   (e.g. a metadata plugin on the editor which passes the documentId)
      * @returns {Object} {label, value, ?isDefault}
      */
     async fetch({projectId, userId, params}) {

--- a/content/operations/releases/release-2025-05.md
+++ b/content/operations/releases/release-2025-05.md
@@ -110,6 +110,13 @@ The Menu Tool has been removed.
 The deprecated shorthand property `config.contentTypes` in the li-document-search metadata plugin was now removed.
 Use `config.contentType` instead.
 
+{{< feature-info "Server" "Removal" >}}
+
+### Removal of params.documentId in Data Sources :fire:
+
+The `params.documentId` is no longer included in data source requests originating from the editor.
+If your integration depends on this parameter, please reach out to us to discuss alternative solutions.
+
 ## Deprecations
 
 There have been no deprecations since the last release.


### PR DESCRIPTION
- No longer sending the `documentId` in data source requests