### PR TITLE
Update supported browser versions

### DIFF
--- a/content/operations/releases/_release-template.md
+++ b/content/operations/releases/_release-template.md
@@ -31,7 +31,7 @@ systemRequirements:
     - name: Livingdocs Editor Docker Image
       version: livingdocs/editor-base:22
     - name: Browser Support
-      version: Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78
+      version: Chrome >= 144, Edge >= 144, Firefox >= 146, Safari >= 26.0
 
   minimal:
     - name: Node
@@ -51,7 +51,7 @@ systemRequirements:
     - name: Livingdocs Editor Docker Image
       version: livingdocs/editor-base:20:10
     - name: Browser Support
-      version: Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78
+      version: Chrome >= 133, Edge >= 133, Firefox >= 135, Safari >= 18.3
 ---
 
 ## Caveat :fire:

--- a/content/operations/releases/release-2025-11.md
+++ b/content/operations/releases/release-2025-11.md
@@ -31,7 +31,7 @@ systemRequirements:
     - name: Livingdocs Editor Docker Image
       version: livingdocs/editor-base:22
     - name: Browser Support
-      version: Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78
+      version: Chrome >= 142, Edge >= 142, Firefox >= 144, Safari >= 26.0
 
   minimal:
     - name: Node
@@ -51,7 +51,7 @@ systemRequirements:
     - name: Livingdocs Editor Docker Image
       version: livingdocs/editor-base:20:10
     - name: Browser Support
-      version: Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78
+      version: Chrome >= 130, Edge >= 130, Firefox >= 132, Safari >= 18.1
 ---
 
 ## Caveat :fire:

--- a/content/operations/releases/release-2026-01.md
+++ b/content/operations/releases/release-2026-01.md
@@ -31,7 +31,7 @@ systemRequirements:
     - name: Livingdocs Editor Docker Image
       version: livingdocs/editor-base:22
     - name: Browser Support
-      version: Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78
+      version: Chrome >= 144, Edge >= 144, Firefox >= 146, Safari >= 26.0
 
   minimal:
     - name: Node
@@ -51,7 +51,7 @@ systemRequirements:
     - name: Livingdocs Editor Docker Image
       version: livingdocs/editor-base:20:10
     - name: Browser Support
-      version: Edge >= 92, Firefox >= 90, Chrome >= 92, Safari >= 15.4, iOS Safari >= 15.4, Opera >= 78
+      version: Chrome >= 131, Edge >= 131, Firefox >= 133, Safari >= 18.2
 ---
 
 ## Caveat :fire:


### PR DESCRIPTION
- I've updated the versions to 1 year before the next release month, so in this case they are the most recent versions from October 2024 ready for the November 2025 release. If there's ever a difference between the Chrome and Edge version then I would make Edge match the Chrome version even if it ends up being 51 weeks old. Edge seems to have the an aggressive update policy so I doubt this will be an issue.
- I've dropped iOS Safari because it's always the same version as regular Safari, and we don't list Chrome for Android separately (even though Can I use... lists these separately).
- I've dropped Opera because we only had 10 of 4000 users on TrackJS using it, it's based on Chrome (or at least the same engines), it's generally up-to-date versions that we see, and I don't think anyone is actively developing or testing with it.