### PR TITLE
Deprecate channel endpoints of public api

### DIFF
--- a/content/operations/releases/release-2025-07.md
+++ b/content/operations/releases/release-2025-07.md
@@ -291,10 +291,26 @@ Support for it will be removed in `release-2026-01`.
 
 {{< feature-info "Server API" "Server" >}}
 
-### Deprecate endpoint `GET /api/:apiVersion/channelConfig` :warning:
+### Deprecation of `/project`, `/channelConfig` and `/channels/{channelHandle}` endpoints :warning:
 
-The endpoint `GET /api/:apiVersion/channelConfig` is deprecated and `/api/2025-05/channelConfig` is the last api version that supports it.  
-Please use `/api/2025-07/projectConfig` instead.
+The following endpoints are no longer available in newer api versions anymore:
+
+❌ `GET` `/api/2025-07/project`  
+❌ `GET` `/api/2025-07/channels/{channelHandle}`  
+❌ `GET` `/api/2025-07/channelConfig`  
+❌ `POST` `/api/2025-07/channelConfig`
+
+Please use the following endpoints instead, which are available since v1:
+
+✅ `GET` `/api/2025-07/projectConfig`  
+✅ `POST` `/api/2025-07/projectConfig`
+
+All the 4 legacy endpoints are still available in v1 to 2025-05:
+
+✅ `GET` `/api/v1/project` to `/api/2025-05/project`  
+✅ `GET` `/api/v1/channels` to `/api/2025-05/channels`  
+✅ `GET` `/api/v1/channelConfig` to `/api/2025-05/channelConfig`  
+✅ `POST` `/api/v1/channelConfig` to `/api/2025-05/channelConfig`
 
 {{< feature-info "Removal" "Server" >}}
 

--- a/content/reference/public-api/changelog/2025-07/channel-endpoints-deprecation.md
+++ b/content/reference/public-api/changelog/2025-07/channel-endpoints-deprecation.md
@@ -1,0 +1,28 @@
+---
+title: 'Deprecation of `/project`, `/channelConfig` and `/channels/{channelHandle}` endpoints'
+type: changelog-entry
+weight: 1
+
+change:
+  date: 2025-07
+  type: deprecation
+---
+
+The following endpoints are no longer available in newer api versions anymore:
+
+❌ `GET` `/api/2025-07/project`  
+❌ `GET` `/api/2025-07/channels/{channelHandle}`  
+❌ `GET` `/api/2025-07/channelConfig`  
+❌ `POST` `/api/2025-07/channelConfig`
+
+Please use the following endpoints instead, which are available since v1:
+
+✅ `GET` `/api/2025-07/projectConfig`  
+✅ `POST` `/api/2025-07/projectConfig`
+
+All the 4 legacy endpoints are still available in v1 to 2025-05:
+
+✅ `GET` `/api/v1/project` to `/api/2025-05/project`  
+✅ `GET` `/api/v1/channels` to `/api/2025-05/channels`  
+✅ `GET` `/api/v1/channelConfig` to `/api/2025-05/channelConfig`  
+✅ `POST` `/api/v1/channelConfig` to `/api/2025-05/channelConfig`

--- a/data/endpoints/get-channel-configuration.yaml
+++ b/data/endpoints/get-channel-configuration.yaml
@@ -1,8 +1,22 @@
 title: Get Channel Configuration
 
+apiVersionConstraints:
+  lt: 2025-07
+
+history:
+  - release: release-2023-03
+    version: v1
+    description: This endpoint got deprecated. Please use `GET /api/v1/projectConfig` instead.
+  - release: release-2025-07
+    version: 2025-07
+    description: This endpoint got removed in the `2025-07` version. It's still available on `/api/2025-05/project` and older versions.
+
 deprecation:
   since: release-2023-03
-  note: Use `GET /api/:apiVersion/projectConfig` instead.
+  note: |
+    Use `GET /api/:apiVersion/projectConfig` instead.<br>
+    This endpoint got removed in the `2025-07` version.<br>
+    It's still available on `/api/2025-05/channels/{channelHandle}` and older versions.
 
 scopes: public-api:read
 query: |
@@ -18,7 +32,6 @@ parameters:
     required: false
     notes: Optional channelHandle. Will return first channel of a project if none is passed.
 
-deprecated: release-2023-03
 responses:
   - code: '200'
     body: |

--- a/data/endpoints/get-project-config.yaml
+++ b/data/endpoints/get-project-config.yaml
@@ -13,8 +13,7 @@ query: |
 endpoint:
   method: GET
   path: /api/:apiVersion/projectConfig
-deprecated_endpoints:
-  - GET api/v1/channelConfig
+
 responses:
   - code: '200'
     body: |

--- a/data/endpoints/get-project-configuration.yaml
+++ b/data/endpoints/get-project-configuration.yaml
@@ -1,18 +1,33 @@
 title: Get Project Configuration
 
+apiVersionConstraints:
+  lt: 2025-07
+
+history:
+  - release: release-2023-03
+    version: v1
+    description: This endpoint got deprecreated. Use `GET /api/v1/projectConfig` instead.
+  - release: release-2025-07
+    version: 2025-07
+    description: This endpoint got removed in the `2025-07` version. It's still available on `/api/2025-05/project` and older versions.
+
 deprecation:
   since: release-2023-03
-  note: Use `GET /api/v1/projectConfig` instead.
+  note: |
+    Use `GET /api/:apiVersion/projectConfig` instead.<br>
+    This endpoint got removed in the `2025-07` version.<br>
+    It's still available on `/api/2025-05/project` and older versions.
 
 scopes: public-api:read
 query: |
   ACCESS_TOKEN=ey1234
   curl -k -X GET "https://server.livingdocs.io/api/:apiVersion/project" \
     -H "Authorization: Bearer $ACCESS_TOKEN"
+
 endpoint:
   method: GET
   path: /api/:apiVersion/project
-deprecated: release-2023-03
+
 responses:
   - code: '200'
     body: |

--- a/themes/hugo-docs/layouts/changelog/section.html
+++ b/themes/hugo-docs/layouts/changelog/section.html
@@ -88,7 +88,7 @@
               </div>
 
               <main class="changelog--entry-main">
-                <h3 class="changelog--entry-title">{{ .Title }}</h3>
+                <h3 class="changelog--entry-title">{{ .Title | markdownify }}</h3>
                 {{ .Content }}
               </main>
             </div>


### PR DESCRIPTION
### Changelog
- ⚠️ Deprecation of `/project`, `/channelConfig` and `/channels/{channelHandle}` endpoints