### PR TITLE
Remove unused `useHistoryRestore` property

### DIFF
--- a/content/customising/advanced/editor-configuration/editing-features.md
+++ b/content/customising/advanced/editor-configuration/editing-features.md
@@ -145,18 +145,6 @@ When you have your own Iframely account, you should disable this [setting](https
 
 See [here]({{< ref "./text-editing.md#spellcheck" >}})
 
-## Document History
-
-```js
-{
-  app: {
-    useHistoryRestore: true
-  }
-}
-```
-
-The `useHistoryRestore` option enables / disables the restore functionality in the document history, i.e. the ability to restore the opened document to an older revision.
-
 ## Links
 
 See [here]({{< ref "./text-editing.md#links" >}})


### PR DESCRIPTION
- Related PR: https://github.com/livingdocsIO/livingdocs-editor/pull/1774

The `useHistoryRestore` property was implemented in 2018 and but longer existed at some point in 2019. Presumably this was used as a beta flag in case it caused problems.
