### PR TITLE
Improve Notifications reference and guide and add Microsoft Teams channel

### DIFF
--- a/content/customising/server-configuration/_index.md
+++ b/content/customising/server-configuration/_index.md
@@ -1410,20 +1410,27 @@ There is a general `integrations` configuration for small integrations that can 
 
 ```js
   notifications: {
-    // Enables notification feature over specified channels: slack, email
+    // Enables notification feature over specified channels
     enabled: false,
     // Enables consumer jobs for the specified channels
     // To be modified in read-only server instances
     // Can also be modified removing `['worker']` role, which disables consumers
     enableConsumers: true,
-    // Defines channels to use: slack, email
+    // Defines channels to use: slack, teams, email
     channels: {
       email: {
         enabled: false,
         fromAddress: 'noreply@livingdocs.dev'
       },
       slack: {
-        enabled: false
+        enabled: false,
+        // Slack documentation on how to create and retrieve that token
+        // https://api.slack.com/authentication/token-types#bot
+        botUserToken: 'botUserToken'
+      },
+      teams: {
+        enabled: false,
+        botUrl: 'https://botUrl'
       }
     }
   },

--- a/content/guides/editor/notifications/index.md
+++ b/content/guides/editor/notifications/index.md
@@ -10,7 +10,7 @@ In a nutshell, _Notifications_ enable editors to actively track interesting chan
 
 Let's have an example with a _Proofreading task_. Let's assume Proofreaders are interested to know if a certain article has been marked for proofreading so that the article can be published with lightspeed once they finished the task.
 
-If they subscribe for changes on a specific document they will get an E-Mail or Slack notification that the document was marked for proofreading.
+If they subscribe for changes on a specific document they will get an E-Mail, Slack or Teams notification that the document was marked for proofreading.
 
 The basic idea is to improve production speed by pushing information to the editors instead of pulling, so going to a colleague and asking if an article is ready for proofreading, review, or publishing.
 
@@ -24,7 +24,7 @@ module.exports = {
   notifications: {
     enabled: true,
     enableConsumers: true,
-    // only email and slack are available at the moment
+    // only email, slack and teams are available at the moment
     channels: {
       email: {
         enabled: true,
@@ -35,6 +35,10 @@ module.exports = {
         // Slack documentation on how to create and retrieve that token
         // https://api.slack.com/authentication/token-types#bot
         botUserToken: 'botUserToken'
+      },
+      teams: {
+        enabled: true,
+        botUrl: 'https://botUrl'
       }
     }
   },
@@ -66,8 +70,27 @@ module.exports = {
 }
 ```
 
-The `enableConsumers` is the configuration used to enable/disable the email, slack consumers.
+The `enableConsumers` is the configuration used to enable/disable the email/slack/teams consumers.
 By default, they will be enabled in server instances that define `roles: ['worker']` in server configuration.
+
+### Setup Slack
+
+1. Go to https://api.slack.com/apps/
+2. “Create new app”
+3. select from scratch
+4. Add it to your workspace
+5. Go to the app & go to ‘oauth and permissions’
+6. use the Bot User OAuth Access Token and add the following scopes:
+   - `chat:write`
+   - `chat:write.customize`
+   - `users:read`
+   - `users:read.mail`
+7. install the app on the workspace
+8. Add `Bot User OAuth Token` to the Livingdocs `notifications.channels.slack.botUserToken` config
+
+### Setup Teams
+
+For further information on creating a bot for Microsoft Teams please see the Microsoft [Build bots](https://learn.microsoft.com/en-gb/microsoftteams/platform/bots/overview) documentation.
 
 ## Project config
 
@@ -155,21 +178,6 @@ In a comment it is possible to mention a user with `@`. A dropdown will be shown
 ![Comments mentioning](./comments-mentioning.png)
 
 As soon as the comments are enabled it is possible to mention another user in a comment. The other user will get a notification when they are enabled. The user doesn't have to watch a document to get the notification.
-
-## Setup Slack
-
-1. Go to https://api.slack.com/apps/
-2. “Create new app”
-3. select from scratch
-4. Add it to your workspace
-5. Go to the app & go to ‘oauth and permissions’
-6. use the Bot User OAuth Access Token and add the following scopes:
-   - `chat:write`
-   - `chat:write.customize`
-   - `users:read`
-   - `users:read.mail`
-7. install the app on the workspace
-8. Add `Bot User OAuth Token` to the Livingdocs `notifications.channels.slack.botUserToken` config
 
 ## Additional notifications
 

--- a/content/guides/editor/notifications/index.md
+++ b/content/guides/editor/notifications/index.md
@@ -58,9 +58,8 @@ module.exports = {
       notifications: {
         transport: 'default',
         subject: 'Changes on a document you are subscribed to',
-        htmlTemplatePath: require.resolve(
-          '@livingdocs/server/plugins/email-templates/notifications.html'
-        )
+        htmlTemplatePath:
+          require.resolve('@livingdocs/server/plugins/email-templates/notifications.html')
       }
     }
   }
@@ -70,7 +69,7 @@ module.exports = {
 The `enableConsumers` is the configuration used to enable/disable the email, slack consumers.
 By default, they will be enabled in server instances that define `roles: ['worker']` in server configuration.
 
-### Project config
+## Project config
 
 Certain _actions groups_ can be defined within the [project config for notifications]({{< ref "/reference/project-config/notifications.md" >}}).
 
@@ -137,7 +136,7 @@ Possible action to register on at the moment:
 - document.delete
 - document.transform
 - comment.add
-- task.assign
+- comment.resolve
 - task.change
   config options:
 
@@ -149,7 +148,7 @@ Possible action to register on at the moment:
   {type: 'task.change', taskName: 'proofreading', statusChange: ['requested', 'accepted', 'completed']}
   ```
 
-#### Comments mentioning
+## Comments mentioning
 
 In a comment it is possible to mention a user with `@`. A dropdown will be shown and a user can be selected. This user will get a notification about the mentioning in a comment.
 
@@ -157,7 +156,7 @@ In a comment it is possible to mention a user with `@`. A dropdown will be shown
 
 As soon as the comments are enabled it is possible to mention another user in a comment. The other user will get a notification when they are enabled. The user doesn't have to watch a document to get the notification.
 
-### Setup Slack
+## Setup Slack
 
 1. Go to https://api.slack.com/apps/
 2. “Create new app”
@@ -171,3 +170,11 @@ As soon as the comments are enabled it is possible to mention another user in a 
    - `users:read.mail`
 7. install the app on the workspace
 8. Add `Bot User OAuth Token` to the Livingdocs `notifications.channels.slack.botUserToken` config
+
+## Additional notifications
+
+Along with comment mentions (above) the following notifications can occur without manual subscription by a user:
+
+- When a user is assigned to a task by another user they will receive a notification.
+- When `notifyTaskRequester` is enabled the task creator will receive notifications when the specific task is accepted or completed.
+- When `autoSubscribeOwner` is enabled the creator of the document will be automatically subscribed to notifications for all events in the specified action group.

--- a/content/reference/project-config/notifications.md
+++ b/content/reference/project-config/notifications.md
@@ -8,8 +8,7 @@ menu:
 
 You can configure `notifications` to enable the possibility that a user can get notifications for changes on a document.
 
-There is also a guide how to configure the notifications.
-[Notification guide]({{< ref "/guides/editor/notifications.md" >}})
+There is also a [Setup Notifications]({{< ref "/guides/editor/notifications.md" >}}) guide about how to configure the notifications.
 
 ```js
 notifications: {
@@ -40,8 +39,15 @@ notifications: {
 }
 ```
 
-Possible action to register on at the moment:
+Possible actions to register on at the moment:
 
+- document.publish
+- document.unpublish
+- document.copy
+- document.delete
+- document.transform
+- comment.add
+- comment.resolve
 - task.change
   config options:
 
@@ -52,15 +58,3 @@ Possible action to register on at the moment:
    // assign to task proofreading on statusChanges 'requested', 'accepted', 'completed'
   {type: 'task.change', taskName: 'proofreading', statusChange: ['requested', 'accepted', 'completed']}
   ```
-
-- document.publish
-- document.unpublish
-- document.copy
-- document.delete
-- document.transform
-- comment.add
-- comment.resolve
-
-A user can be mentioned in comment. [Comments mentioning]({{< ref "/guides/editor/notifications.md#comments-mentioning" >}})
-
-The comments mentioning doesn't have to be configured. It will work automatically as soon as the comments and the notifications are enabled.


### PR DESCRIPTION
I looked into the Notifications after a [Slack request](https://livingdocs.slack.com/archives/C4TGTEC3F/p1771913700999779) for further information. I found a few inconsistencies so I have tried to tidy things up. I do not know enough about setting up a Microsoft Teams bot to add further details to this section.