### PR TITLE
Add usage log entry operations to Public API

### DIFF
--- a/content/operations/releases/release-2026-05.md
+++ b/content/operations/releases/release-2026-05.md
@@ -64,6 +64,7 @@ These are the release notes of the upcoming release (pull requests merged to the
 - :fire: Integration against the upcoming release (currently `main` branch) is at your own risk
 
 ## PRs to Categorize
+
 - [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-server/pull/9227)
 - [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-editor/pull/10980)
 - [fix(deps): update dependency @livingdocs/framework from 33.0.3 to v33.0.4 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/9223)
@@ -215,6 +216,78 @@ Please use the following replacements instead:
 ## Deprecations
 
 ## Features :gift:
+
+### Public API Endpoint to get the Usage Log of a Media Library Entry :gift:
+
+A new endpoint has been added, `GET /api/:apiVersion/mediaLibrary/:id/usageLog`, which returns all usage log entries for the specified media library entry. Further details can be found in the [Get the Usage Log of a Media Library Entry]({{< ref "/reference/public-api/media-library/#get-the-usage-log-of-a-media-library-entry" >}}) endpoint documentation.
+
+### Public API Operations to Modify Media Library Entry Usage Log Entries :gift:
+
+The Media Library Entry patch endpoint in the public API has been extended to allow external systems (e.g. print system) to report the usage of a media library entry and provide the details.
+
+Add a new entry:
+
+`PATCH /api/2026-05/mediaLibrary/{id}`
+
+```json
+{
+  "preserveUpdatedAt": true,
+  "patches": [
+    {
+      "operation": "addUsageLogEntry",
+      "value": {
+        "state": "pending", // Optional 'pending' or 'confirmed' (default: 'pending')
+        "purpose": "print", // Required handle of usage log purpose
+        "publicationDate": "2026-05-01T11:00:00.000Z", // Required when state is 'confirmed'
+        "url": "http://localhost", // Optional link to external editor or delivery
+        "params": {} // Any value for params defined in the `paramsSchema` of the selected purpose
+      }
+    }
+  ]
+}
+```
+
+Update an entry:
+
+`PATCH /api/2026-05/mediaLibrary/{id}`
+
+```json
+{
+  "preserveUpdatedAt": true,
+  "patches": [
+    {
+      "operation": "updateUsageLogEntry",
+      "usageLogEntryId": "g1x419UgQSS5",
+      "value": {
+        "state": "confirmed", // Required for updates
+        "purpose": "print",
+        "publicationDate": "2026-05-01T11:00:00.000Z",
+        "url": "http://localhost",
+        "params": {
+          "medium": "Paper"
+        }
+      },
+      "oldValue": {} // Optional expected state condition
+    }
+  ]
+}
+```
+
+Remove an entry:
+
+`PATCH /api/2026-05/mediaLibrary/{id}`
+
+```json
+{
+  "preserveUpdatedAt": true,
+  "patches": [
+    {
+      "operation": "removeUsageLogEntry",
+      "usageLogEntryId": "g1x419UgQSS5"
+    }
+  ]
+}
+```
 
 ## Vulnerability Patches
 

--- a/content/reference/public-api/changelog/2026-05/usage-log-get.md
+++ b/content/reference/public-api/changelog/2026-05/usage-log-get.md
@@ -1,0 +1,11 @@
+---
+title: Get Usage Log of Media Library Entry
+type: changelog-entry
+weight: 1
+
+change:
+  date: 2026-05
+  type: feature
+---
+
+A new endpoint has been added, `GET /api/:apiVersion/mediaLibrary/:id/usageLog`, which returns all usage log entries for the specified media library entry. Further details can be found in the [Get the Usage Log of a Media Library Entry]({{< ref "/reference/public-api/media-library/#get-the-usage-log-of-a-media-library-entry" >}}) endpoint documentation.

--- a/content/reference/public-api/changelog/2026-05/usage-log-patch.md
+++ b/content/reference/public-api/changelog/2026-05/usage-log-patch.md
@@ -1,0 +1,13 @@
+---
+title: Add Usage Log Operations to Media Library Patch
+type: changelog-entry
+weight: 2
+
+change:
+  date: 2026-05
+  type: feature
+---
+
+The Media Library Entry patch endpoint in the public API has been extended to allow external systems (e.g. print system) to report the usage of a media library entry and provide the details.
+
+The new operations are `addUsageLogEntry`, `updateUsageLogEntry` and `removeUsageLogEntry`. Further details can be found in the [Patch a Media Library Entry]({{< ref "/reference/public-api/media-library/#patch-a-media-library-entry" >}}) endpoint documentation.

--- a/data/endpoints/get-media-library-entry-usage-log.yaml
+++ b/data/endpoints/get-media-library-entry-usage-log.yaml
@@ -1,0 +1,102 @@
+title: Get the Usage Log of a Media Library Entry
+
+history:
+  - release: release-2026-05
+    description: Initial support.
+
+description: |
+  Fetch the Usage Log of a Media Library Entry.
+
+scopes: public-api:read
+endpoint:
+  method: GET
+  path: /api/:apiVersion/mediaLibrary/{id}/usageLog
+responses:
+  - code: '200'
+    endpoint: /api/:apiVersion/mediaLibrary/{id}/usageLog
+    body: |
+      {
+        "results": [
+          {
+            "id": "g6Hmp49Y",
+            "url": "https://example.com/article/slug-121",
+            "state": "confirmed",
+            "params": {
+              "medium": "Internet"
+            },
+            "purpose": "web",
+            "documentId": 121,
+            "publicationId": 110,
+            "reportingDate": "2026-04-02T13:34:30.263Z",
+            "publicationDate": "2026-04-02T13:34:26.353Z"
+          }
+        ]
+      }
+
+openapi:
+  security:
+    - bearerAuth:
+        - public-api:read
+  tags:
+    - Media Library
+  operationId: getMediaLibraryEntryUsageLog
+  summary: Get the Usage Log of a Media Library Entry
+  description: Fetch the Usage Log of a Media Library Entry
+  parameters:
+    - name: id
+      description: Id of a Media Library entry
+      in: path
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: ok
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              results:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                    url:
+                      type: string
+                      format: url
+                    state:
+                      type: string
+                      enum:
+                        - pending
+                        - confirmed
+                    params:
+                      type: object
+                    purpose:
+                      type: string
+                    documentId:
+                      type: integer
+                    publicationId:
+                      type: integer
+                    reportingDate:
+                      type: string
+                      format: date-time
+                    publicationDate:
+                      type: string
+                      format: date-time
+          examples:
+            success:
+              value:
+                results:
+                  - id: 'g6Hmp49Y'
+                    url: 'https://example.com/article/slug-121'
+                    state: 'confirmed'
+                    params:
+                      medium: 'Internet'
+                    purpose: 'web'
+                    documentId: 121
+                    publicationId: 110
+                    reportingDate: '2026-04-02T13:34:30.263Z'
+                    publicationDate: '2026-04-02T13:34:26.353Z'

--- a/data/endpoints/incoming-draft-references-for-document.yaml
+++ b/data/endpoints/incoming-draft-references-for-document.yaml
@@ -138,7 +138,8 @@ openapi:
                 items:
                   type: object
                   properties:
-                    id: integer
+                    id:
+                      type: integer
                     references:
                       type: array
                       items:

--- a/data/endpoints/incoming-media-references-for-document.yaml
+++ b/data/endpoints/incoming-media-references-for-document.yaml
@@ -121,7 +121,8 @@ openapi:
                 items:
                   type: object
                   properties:
-                    id: integer
+                    id:
+                      type: integer
                     references:
                       type: array
                       items:

--- a/data/endpoints/incoming-media-references-for-media.yaml
+++ b/data/endpoints/incoming-media-references-for-media.yaml
@@ -114,7 +114,8 @@ openapi:
                 items:
                   type: object
                   properties:
-                    id: integer
+                    id:
+                      type: integer
                     references:
                       type: array
                       items:

--- a/data/endpoints/incoming-publication-references-for-document.yaml
+++ b/data/endpoints/incoming-publication-references-for-document.yaml
@@ -149,7 +149,8 @@ openapi:
                 items:
                   type: object
                   properties:
-                    id: integer
+                    id:
+                      type: integer
                     references:
                       type: array
                       items:

--- a/data/endpoints/incoming-publication-references-for-media.yaml
+++ b/data/endpoints/incoming-publication-references-for-media.yaml
@@ -146,7 +146,8 @@ openapi:
                 items:
                   type: object
                   properties:
-                    id: integer
+                    id:
+                      type: integer
                     references:
                       type: array
                       items:

--- a/data/endpoints/patch-media-library-entry-2026-01.yaml
+++ b/data/endpoints/patch-media-library-entry-2026-01.yaml
@@ -5,6 +5,8 @@ apiVersionConstraints:
   lte: 2026-01
 
 history:
+  - release: release-2026-05
+    description: Added `addUsageLogEntry`, `updateUsageLogEntry` and `removeUsageLogEntry` operations.
   - release: release-2026-01
     description: Added `unrevokeAsset` operation.<br>
       Added the `note` property to be used with the `revokeAsset` operation.
@@ -41,11 +43,22 @@ parameters:
     required: true
     notes: |
       An array of patches to execute. Each entry is an object with the following keys:
-      - **operation** `setMetadataProperty`, `replaceAsset`, `revokeAsset`, `unrevokeAsset` ({{< added-in "release-2026-01" >}}), `archive` or `removeAsset`
+      - **operation**
+        - `setMetadataProperty`
+        - `archive`
+        - `replaceAsset`
+        - `removeAsset`
+        - `revokeAsset`
+        - `unrevokeAsset` ({{< added-in "release-2026-01" >}})
+        - `addUsageLogEntry` ({{< added-in "release-2026-05" >}})
+        - `updateUsageLogEntry` ({{< added-in "release-2026-05" >}})
+        - `removeUsageLogEntry` ({{< added-in "release-2026-05" >}})
       - **propertyName** string of the propertyName (only for setMetadataProperty)
       - **value** string or object for the new value. If set to null or value is not set it will remove the property for setMetadataProperty. **required** for replaceAsset operation.
       - **locale** string of the asset to be removed (only in multilingual setups for removeAsset)
       - **note** optional string with a maximum length of 200 characters. Only supported by the `revokeAsset` operation. ({{< added-in "release-2026-01" >}})
+      - **usageLogEntryId** required string to identify the usage log entry to operate on. Only supported by the `updateUsageLogEntry` and `removeUsageLogEntry` operations. ({{< added-in "release-2026-05" >}})
+      - **oldValue** optional object containing the previous usage log entry which must match for the operation to proceed. Only supported by the `updateUsageLogEntry` operation. ({{< added-in "release-2026-05" >}})
 
 example_request: |
   {
@@ -88,6 +101,37 @@ example_request: |
         // removes a translated asset (the default locale asset cannot be removed)
         "operation": "removeAsset",
         "locale": "en"
+      },
+      // add a usage log entry
+      {
+        operation: 'addUsageLogEntry',
+        value: {
+          state: 'pending', // Optional 'pending' or 'confirmed' (default: 'pending')
+          purpose: 'print', // Required handle of usage log purpose
+          publicationDate: '2026-05-01T11:00:00.000Z', // Required when state is 'confirmed'
+          url: 'http://localhost', // Optional link to external editor or delivery
+          params: {} // Any value for params defined in the `paramsSchema` of the selected purpose
+        }
+      },
+      // update a usage log entry
+      {
+        operation: 'updateUsageLogEntry',
+        usageLogEntryId: 'g1x419UgQSS5',
+        value: {
+          state: 'confirmed', // Required for updates
+          purpose: 'print',
+          publicationDate: '2026-05-01T11:00:00.000Z',
+          url: 'http://localhost',
+          params: {
+            medium: 'Paper'
+          }
+        },
+        oldValue: {} // Optional expected state condition
+      },
+      // remove a usage log entry
+      {
+        operation: 'removeUsageLogEntry',
+        usageLogEntryId: 'g1x419UgQSS5'
       }
     ]
   }
@@ -181,9 +225,30 @@ openapi:
                     filename: my-new-file.png
                     mimeType: image/png
                 - operation: revokeAsset
+                  note: 'Case #1'
+                - operation: unrevokeAsset
                 - operation: archive
                 - operation: removeAsset
                   locale: en
+                - operation: addUsageLogEntry
+                  value:
+                    state: 'pending'
+                    purpose: 'print'
+                    publicationDate: '2026-05-01T11:00:00.000Z'
+                    url: 'http://localhost'
+                    params: {}
+                - operation: updateUsageLogEntry
+                  usageLogEntryId: g1x419UgQSS5
+                  value:
+                    state: 'confirmed'
+                    purpose: 'print'
+                    publicationDate: '2026-05-01T11:00:00.000Z'
+                    url: 'http://localhost'
+                    params:
+                      medium: 'Paper'
+                  oldValue: {}
+                - operation: removeUsageLogEntry
+                  usageLogEntryId: g1x419UgQSS5
   responses:
     '200':
       description: ok

--- a/data/endpoints/patch-media-library-entry.yaml
+++ b/data/endpoints/patch-media-library-entry.yaml
@@ -5,6 +5,8 @@ apiVersionConstraints:
   gte: 2026-03
 
 history:
+  - release: release-2026-05
+    description: Added `addUsageLogEntry`, `updateUsageLogEntry` and `removeUsageLogEntry` operations.
   - release: release-2026-03
     description: Added `preserveUpdatedAt` parameter. When set to `true`, the entry's `updated_at` timestamp is not modified. This is useful for imports and migrations where the original timestamps should be preserved.
   - release: release-2026-01
@@ -42,6 +44,8 @@ parameters:
     type: boolean
     required: false
     notes: |
+      {{< added-in "release-2026-03" block >}}
+
       When set to `true`, the entry's `updated_at` timestamp is not modified by the patch operation. By default (`false`), `updated_at` is set to the current time.
 
       This is useful for imports and migrations where the original timestamps should be preserved to maintain correct sort order.
@@ -50,11 +54,22 @@ parameters:
     required: true
     notes: |
       An array of patches to execute. Each entry is an object with the following keys:
-      - **operation** `setMetadataProperty`, `replaceAsset`, `revokeAsset`, `unrevokeAsset` ({{< added-in "release-2026-01" >}}), `archive` or `removeAsset`
+      - **operation**
+        - `setMetadataProperty`
+        - `archive`
+        - `replaceAsset`
+        - `removeAsset`
+        - `revokeAsset`
+        - `unrevokeAsset` ({{< added-in "release-2026-01" >}})
+        - `addUsageLogEntry` ({{< added-in "release-2026-05" >}})
+        - `updateUsageLogEntry` ({{< added-in "release-2026-05" >}})
+        - `removeUsageLogEntry` ({{< added-in "release-2026-05" >}})
       - **propertyName** string of the propertyName (only for setMetadataProperty)
       - **value** string or object for the new value. If set to null or value is not set it will remove the property for setMetadataProperty. **required** for replaceAsset operation.
       - **locale** string of the asset to be removed (only in multilingual setups for removeAsset)
       - **note** optional string with a maximum length of 200 characters. Only supported by the `revokeAsset` operation. ({{< added-in "release-2026-01" >}})
+      - **usageLogEntryId** required string to identify the usage log entry to operate on. Only supported by the `updateUsageLogEntry` and `removeUsageLogEntry` operations. ({{< added-in "release-2026-05" >}})
+      - **oldValue** optional object containing the previous usage log entry which must match for the operation to proceed. Only supported by the `updateUsageLogEntry` operation. ({{< added-in "release-2026-05" >}})
 
 example_request: |
   {
@@ -99,6 +114,37 @@ example_request: |
         // removes a translated asset (the default locale asset cannot be removed)
         "operation": "removeAsset",
         "locale": "en"
+      },
+      // add a usage log entry
+      {
+        operation: 'addUsageLogEntry',
+        value: {
+          state: 'pending', // Optional 'pending' or 'confirmed' (default: 'pending')
+          purpose: 'print', // Required handle of usage log purpose
+          publicationDate: '2026-05-01T11:00:00.000Z', // Required when state is 'confirmed'
+          url: 'http://localhost', // Optional link to external editor or delivery
+          params: {} // Any value for params defined in the `paramsSchema` of the selected purpose
+        }
+      },
+      // update a usage log entry
+      {
+        operation: 'updateUsageLogEntry',
+        usageLogEntryId: 'g1x419UgQSS5',
+        value: {
+          state: 'confirmed', // Required for updates
+          purpose: 'print',
+          publicationDate: '2026-05-01T11:00:00.000Z',
+          url: 'http://localhost',
+          params: {
+            medium: 'Paper'
+          }
+        },
+        oldValue: {} // Optional expected state condition
+      },
+      // remove a usage log entry
+      {
+        operation: 'removeUsageLogEntry',
+        usageLogEntryId: 'g1x419UgQSS5'
       }
     ]
   }
@@ -196,9 +242,30 @@ openapi:
                     filename: my-new-file.png
                     mimeType: image/png
                 - operation: revokeAsset
+                  note: 'Case #1'
+                - operation: unrevokeAsset
                 - operation: archive
                 - operation: removeAsset
                   locale: en
+                - operation: addUsageLogEntry
+                  value:
+                    state: 'pending'
+                    purpose: 'print'
+                    publicationDate: '2026-05-01T11:00:00.000Z'
+                    url: 'http://localhost'
+                    params: {}
+                - operation: updateUsageLogEntry
+                  usageLogEntryId: g1x419UgQSS5
+                  value:
+                    state: 'confirmed'
+                    purpose: 'print'
+                    publicationDate: '2026-05-01T11:00:00.000Z'
+                    url: 'http://localhost'
+                    params:
+                      medium: 'Paper'
+                  oldValue: {}
+                - operation: removeUsageLogEntry
+                  usageLogEntryId: g1x419UgQSS5
   responses:
     '200':
       description: ok

--- a/data/sections.yaml
+++ b/data/sections.yaml
@@ -161,6 +161,7 @@
     - incoming-publication-references-for-media
     - incoming-media-references-for-media
     - media-library-serve-image
+    - get-media-library-entry-usage-log
 
 # Start Imports section
 - title: Imports


### PR DESCRIPTION
- Added `addUsageLogEntry`, `updateUsageLogEntry` and `removeUsageLogEntry` operations to media library patch endpoint of the Public API
- Updated the technical release notes for release-2026-05
- Added an entry into the Public API changelog
- Fixed some invalid OpenAPI schema definitions so that the file will open again! 