### PR TITLE
Create usage log entries on publish

### DIFF
--- a/content/guides/media-library/media-library-setup/index.md
+++ b/content/guides/media-library/media-library-setup/index.md
@@ -798,6 +798,7 @@ Define at least one purpose in the `projectConfig.mediaCenter.usageLog.purposes`
             en: 'Print',
             de: 'Druck'
           },
+          internal: false,
           paramsSchema: [
             {
               handle: 'page',
@@ -818,6 +819,8 @@ Define at least one purpose in the `projectConfig.mediaCenter.usageLog.purposes`
 ```
 
 The purposes are displayed to a user when creating or updating a usage log entry, or when downloading a media library entry. Any additional properties defined within the `paramsSchema` array will also be displayed when creating or updating an entry, but not in the download form. To see which metadata plugins are supported please refer to the [Metadata Plugins List]({{< ref "reference/document/metadata/plugins">}}). We automatically store the reporting date and `userId`, and provide input fields for the publication date, the state ("pending" or "confirmed") and a url.
+
+Usage log purposes can be flagged as internal. When the `internal` property is set to `true` it prevents a user from creating, updating or deleting entries for the purpose within the editor. A read-only entry will still be visible within the UI. This is intended to be used alongside the [`addUsageLogEntriesForMediaInDocument`]({{< ref "#generating-usage-log-entries-on-publish" >}}) function to create permanent entries.
 
 ### Creating usage log dashboards
 
@@ -894,5 +897,25 @@ liEditor.searchFilters.registerListV2('pendingMediaUsageLogs', {
       return options
     }
   }
+})
+```
+
+### Generating usage log entries on publish
+
+The function `mediaLibraryApi.addUsageLogEntriesForMediaInDocument()` can be used to easily create usage log entries. This function is intended to be used in a post publish hook and will add usage log entries for any referenced media library entries which do not already have a usage log entry for the document provided. The entry will automatically be marked as 'confimed' so any mandatory params must be provided.
+
+```js
+liServer.registerInitializedHook(() => {
+  const mediaLibraryApi = liServer.features.api('li-media-library')
+  liServer.registerPublicationHooks({
+    async postPublishHookAsync({documentVersion}) {
+      await mediaLibraryApi.addUsageLogEntriesForMediaInDocument({
+        documentVersion,
+        purpose: 'web',
+        url: `https://example.com/my-slug-${documentVersion.id}`, // Optional
+        params: {medium: 'Internet'} // Required params mandatory
+      })
+    }
+  })
 })
 ```

--- a/content/operations/releases/release-2026-05.md
+++ b/content/operations/releases/release-2026-05.md
@@ -289,6 +289,46 @@ Remove an entry:
 }
 ```
 
+### Create usage log entries on publish :gift:
+
+The function `mediaLibraryApi.addUsageLogEntriesForMediaInDocument()` has been introduced to make it easier to create usage log entries. This function is intended to be used in a post publish hook and will add usage log entries for any referenced media library entries which do not already have a usage log entry for the current document. The entry will automatically be marked as 'confimed' so any mandatory params must be provided.
+
+```js
+liServer.registerInitializedHook(() => {
+  const mediaLibraryApi = liServer.features.api('li-media-library')
+  liServer.registerPublicationHooks({
+    async postPublishHookAsync({documentVersion}) {
+      await mediaLibraryApi.addUsageLogEntriesForMediaInDocument({
+        documentVersion,
+        purpose: 'web',
+        url: `https://example.com/my-slug-${documentVersion.id}`, // Optional
+        params: {medium: 'Internet'} // Required params mandatory
+      })
+    }
+  })
+})
+```
+
+### Internal Usage Log Purposes :gift:
+
+Usage log purposes can now be flagged as internal. When set to `true` it prevents a user from creating, updating or deleting entries for the purpose within the editor. A read-only entry will still be visible within the UI. This is intended to be used alongside the `addUsageLogEntriesForMediaInDocument` function to create permanent entries.
+
+```js
+{
+  mediaCenter: {
+    usageLog: {
+      purposes: [
+        {
+          handle: 'web',
+          label: 'Web',
+          internal: true // <-- New property
+        }
+      ]
+    }
+  }
+}
+```
+
 ## Vulnerability Patches
 
 We are constantly patching module vulnerabilities for the Livingdocs Server and Livingdocs Editor as module fixes are available. Below is a list of all patched vulnerabilities included in the release.

--- a/content/reference/project-config/media-center.md
+++ b/content/reference/project-config/media-center.md
@@ -28,6 +28,7 @@ mediaCenter: {
           en: 'Print',
           de: 'Druck'
         },
+        internal: false,
         paramsSchema: [
           {
             handle: 'page',


### PR DESCRIPTION
Relations:
- Issue: https://www.notion.so/livingdocsio/Media-Center-Create-usage-log-entry-on-publish-document-313c559571d68012a965ce940462d5bc
- Related PRs:
  - https://github.com/livingdocsIO/livingdocs-server/pull/9165
  - https://github.com/livingdocsIO/livingdocs-editor/pull/10945