### PR TITLE
Add release-2026-07 release documentation

### DIFF
--- a/content/operations/releases/release-2026-07.md
+++ b/content/operations/releases/release-2026-07.md
@@ -1,0 +1,154 @@
+---
+type: release-notes
+title: July 2026 Release
+description: Technical Release Notes for release-2026-07
+excludeFromSearch: true
+hideSectionTeaser: true
+
+header:
+  upcoming: true
+  legacy: false
+  current: false
+  maintained: false
+  branchHandle: release-2026-07
+
+systemRequirements:
+  suggested:
+    - name: Node
+      version: 24
+    - name: NPM
+      version: 11
+    - name: Postgres
+      version: 17
+    - name: Elasticsearch
+      version: 9
+    - name: OpenSearch
+      version: 3
+    - name: Redis
+      version: 8
+    - name: Livingdocs Server Docker Image
+      version: livingdocs/server-base:24
+    - name: Livingdocs Editor Docker Image
+      version: livingdocs/editor-base:24
+    - name: Browser Support
+      version: Chrome >= 145, Edge >= 145, Firefox >= 148, Safari >= 26.3
+
+  minimal:
+    - name: Node
+      version: 22.17.1
+    - name: NPM
+      version: 10
+    - name: Postgres
+      version: 14
+    - name: Elasticsearch
+      version: 8
+    - name: OpenSearch
+      version: 2
+    - name: Redis
+      version: 6.2
+    - name: Livingdocs Server Docker Image
+      version: livingdocs/server-base:22
+    - name: Livingdocs Editor Docker Image
+      version: livingdocs/editor-base:22
+    - name: Browser Support
+      version: Chrome >= 138, Edge >= 138, Firefox >= 140, Safari >= 18.6
+---
+
+## Caveat :fire:
+
+These are the release notes of the upcoming release (pull requests merged to the main branch).
+
+- :information_source: this document is updated automatically by a bot (pr's to categorize section)
+- :information_source: this document will be roughly updated manually once a week (put PRs + description to the right section)
+- :fire: We don't guarantee stable APIs. They can still change until the official release
+- :fire: Integration against the upcoming release (currently `main` branch) is at your own risk
+
+## PRs to Categorize
+
+To get an overview about new functionality, read the [Release Notes](TODO).
+To learn about the necessary actions to update Livingdocs to `release-2026-07`, read on.
+
+**Attention:** If you skipped one or more releases, please also check the release-notes of the skipped ones.
+
+## Webinar
+
+- Feature Webinar Recording: **TODO**
+- Feature Webinar Documentation: **TODO**
+- Dev Webinar Recording: **TODO**
+- Dev Webinar Slides: **TODO**
+- [Release Newsletter Subscription](https://confirmsubscription.com/h/j/61B064416E79453D)
+
+## System Requirements
+
+### Suggested
+
+{{< system-versions list="suggested" >}}
+
+### Minimal
+
+{{< system-versions list="minimal" >}}
+
+## Deployment
+
+### Before the deployment
+
+No pre-deployment steps are required before rolling out this release.
+
+### Rollout deployment
+
+#### Migrate the Postgres Database
+
+No migrations are required for this release.
+
+### After the deployment
+
+No post-deployment steps are required after rolling out this release.
+
+### Rollback
+
+No rollback steps are required for this release.
+
+## Breaking Changes :fire:
+
+## Deprecations
+
+## Features :gift:
+
+## Vulnerability Patches
+
+We are constantly patching module vulnerabilities for the Livingdocs Server and Livingdocs Editor as module fixes are available. Below is a list of all patched vulnerabilities included in the release.
+
+### Livingdocs Server
+
+This release we have patched the following vulnerabilities in the Livingdocs Server:
+
+- TBD
+
+No known vulnerabilities. :tada:
+
+### Livingdocs Editor
+
+This release we have patched the following vulnerabilities in the Livingdocs Editor:
+
+- TBD
+
+We are aware of the following vulnerabilities in the Livingdocs Editor:
+
+- [CVE-2023-44270](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) vulnerability in `postcss`, it affects linters using PostCSS to parse external Cascading Style Sheets (CSS). It is not exploitable in the editor as we don't load untrusted external CSS at build time.
+- [CVE-2022-25844](https://github.com/advisories/GHSA-m2h2-264f-f486), [CVE-2022-25869](https://github.com/advisories/GHSA-prc3-vjfx-vhm9), [CVE-2023-26116](https://github.com/advisories/GHSA-2vrf-hf26-jrp5), [CVE-2023-26117](https://github.com/advisories/GHSA-2qqx-w9hr-q5gx), [CVE-2023-26118](https://github.com/advisories/GHSA-qwqh-hm9m-p5hr), [CVE-2024-8372](https://github.com/advisories/GHSA-m9gf-397r-hwpg), [CVE-2024-8373](https://github.com/advisories/GHSA-mqm9-c95h-x2p6), [CVE-2024-21490](https://github.com/advisories/GHSA-4w4v-5hc9-xrr2), [CVE-2025-0716](https://github.com/advisories/GHSA-j58c-ww9w-pwp5) are all AngularJS vulnerabilities that don't have a patch available. We are working on removing all AngularJS from our code and vulnerabilities will go away when we complete the transition to Vue.js.
+- [CVE-2024-9506](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx) vulnerability in `vue`, an ReDoS vulnerability exploitable through inefficient regex evaluation in parseHTML function. The issue can cause excessive CPU usage but is not exploitable in the editor as we don't load untrusted HTML at runtime.
+
+## Patches
+
+Here is a list of all patches after the release has been announced.
+
+### Livingdocs Server Patches
+
+### Livingdocs Editor Patches
+
+---
+
+**Icon Legend**
+
+- Breaking changes: :fire:
+- Feature: :gift:

--- a/data/releases.json
+++ b/data/releases.json
@@ -1,5 +1,17 @@
 {
   "main": {
+    "key": "release-2026-07",
+    "name": "July 2026",
+    "ref": "/operations/releases/release-2026-07.md",
+    "upcoming": true,
+    "current": false,
+    "maintained": false,
+    "legacy": false,
+    "sortId": 56,
+    "editorVersion": "v123.22.0",
+    "serverVersion": "v301.2.0"
+  },
+  "release-2026-05": {
     "key": "release-2026-05",
     "name": "May 2026",
     "ref": "/operations/releases/release-2026-05.md",


### PR DESCRIPTION
# Motivation
As part of the release cut we have to create a new page for the next release in the documentation repository.

You still have to create another PR to update current/maintained/legacy status in the release pages. The PR shall be merged the day the release is announced.

# Changes
- :building_construction: Create a new page for the next release in the documentation repository