### PR TITLE
fix: paginationFindConfig and li-language update

### DIFF
--- a/content/customising/advanced/editor-configuration/display-filter.md
+++ b/content/customising/advanced/editor-configuration/display-filter.md
@@ -96,7 +96,10 @@ You can use Metadata Filters, wherever Display Filters are allowed. The example 
 }
 ```
 
-All metadata properties in your `Content Type`|`Media Type` config can be used as a Metadata Filter, if the metadata type is supported (see below):
+All metadata properties in your `Content Type`|`Media Type` config can be used as a Metadata Filter, if the metadata type is supported (see below).
+
+> **Note:** If you are handling large numbers of data records (100+), ensure that the [`limit` field on `paginationFindConfig`](https://docs.livingdocs.io/customising/server-configuration/#documents) is set to `1000` otherwise only a subset of the total number will be displayed.
+
 
 - [`li-integer`]({{< ref "/reference/document/metadata/plugins/li-integer">}})
 - [`li-category`]({{< ref "/reference/document/metadata/plugins/li-category">}})

--- a/content/customising/advanced/editor-configuration/display-filter.md
+++ b/content/customising/advanced/editor-configuration/display-filter.md
@@ -98,24 +98,22 @@ You can use Metadata Filters, wherever Display Filters are allowed. The example 
 
 All metadata properties in your `Content Type`|`Media Type` config can be used as a Metadata Filter, if the metadata type is supported (see below).
 
-> **Note:** If you are handling large numbers of data records (100+), ensure that the [`limit` field on `paginationFindConfig`](https://docs.livingdocs.io/customising/server-configuration/#documents) is set to `1000` otherwise only a subset of the total number will be displayed.
-
 
 - [`li-integer`]({{< ref "/reference/document/metadata/plugins/li-integer">}})
 - [`li-category`]({{< ref "/reference/document/metadata/plugins/li-category">}})
 - [`li-document-reference`]({{< ref "/reference/document/metadata/plugins/li-document-reference">}}) {{< added-in "release-2023-09" >}}
   - Only supported for `minimal` style
-  - Shows a max of 1000 filter options
+  - Shows a max of 1000 filter options ([Filter limits are handled by the `limit` field on `paginationFindConfig`](https://docs.livingdocs.io/customising/server-configuration/#documents))
 - [`li-document-references`]({{< ref "/reference/document/metadata/plugins/li-document-references">}}) {{< added-in "release-2023-09" >}}
   - Only supported for `minimal` style
-  - Shows a max of 1000 filter options
+  - Shows a max of 1000 filter options ([Filter limits are handled by the `limit` field on `paginationFindConfig`](https://docs.livingdocs.io/customising/server-configuration/#documents))
 - [`li-enum`]({{< ref "/reference/document/metadata/plugins/li-enum">}}) {{< added-in "release-2023-09" >}}
-  - Shows a max of 1000 filter options
+  - Shows a max of 1000 filter options ([Filter limits are handled by the `limit` field on `paginationFindConfig`](https://docs.livingdocs.io/customising/server-configuration/#documents))
 - [`li-text`]({{< ref "/reference/document/metadata/plugins/li-text">}}) {{< added-in "release-2023-09" >}}
   - Only supported if plugin has a `dataProvider`
-  - Shows a max of 1000 filter options
+  - Shows a max of 1000 filter options ([Filter limits are handled by the `limit` field on `paginationFindConfig`](https://docs.livingdocs.io/customising/server-configuration/#documents))
 - [`li-string-list`]({{< ref "/reference/document/metadata/plugins/li-string-list">}}) {{< added-in "release-2023-09" >}}
-  - Shows a max of 1000 filter options
+  - Shows a max of 1000 filter options ([Filter limits are handled by the `limit` field on `paginationFindConfig`](https://docs.livingdocs.io/customising/server-configuration/#documents))
 - [`li-imatrics-nlp-tags`]({{< ref "/reference/document/metadata/plugins/li-imatrics-nlp-tags">}}) {{< added-in "release-2024-05" >}}
 - [`li-retresco`]({{< ref "/reference/document/metadata/plugins/li-retresco">}}) {{< added-in "release-2024-05" >}}
   - To enable the Retresco display filter, modifications on your Retresco TMS instance might be necessary. For more details, please contact your Livingdocs Customer Solutions representative.

--- a/content/reference/document/metadata/plugins/li-language.md
+++ b/content/reference/document/metadata/plugins/li-language.md
@@ -22,7 +22,19 @@ description: |
   When adding `li-language`, it allows a user to translate articles and pages into different languages. Additionally you need to enable [translationWorkflow and requiredOnCreation]({{< ref "/reference/project-config/settings" >}}).
 
   Data Records also support translations, but need to add the metadata plugin [li-metadata-translations]({{< ref "/reference/document/metadata/plugins/li-metadata-translations" >}}).
-defaultUI: None
+defaultUI: |
+    Optional but can be configured as follows:
+
+    ```js
+    ui: {
+      label: 'Language', // optional
+      config: {
+        readOnly: true // optional, default: false
+      }
+    }
+    ```
+
+    This will permit users with multiple languages enabled to change the language metadata field via a dropdown field.
 storageFormat: |
   {
     locale: <String>,


### PR DESCRIPTION
1. Flags the need to configure the limit of the paginationFindConfig value to ensure all data records are displayed in dashboards.

<img width="814" height="700" alt="Screenshot 2026-05-05 at 16 03 52" src="https://github.com/user-attachments/assets/3b806236-3556-482a-992a-889c280aebfa" />

Will appear on: https://docs.livingdocs.io/customising/server-configuration/#documents

2. Makes explicit that li-language plugins have can a visible UI component in the editor

<img width="1086" height="395" alt="Screenshot 2026-05-05 at 16 16 45" src="https://github.com/user-attachments/assets/3bf15abb-0586-4086-8423-b001f10176ab" />
