### PR TITLE
release-2026-05: Update Technical Release Notes

### DIFF
--- a/content/operations/releases/release-2026-05.md
+++ b/content/operations/releases/release-2026-05.md
@@ -54,132 +54,7 @@ systemRequirements:
       version: Chrome >= 136, Edge >= 136, Firefox >= 138, Safari >= 18.4
 ---
 
-## Caveat :fire:
-
-These are the release notes of the upcoming release (pull requests merged to the main branch).
-
-- :information_source: this document is updated automatically by a bot (pr's to categorize section)
-- :information_source: this document will be roughly updated manually once a week (put PRs + description to the right section)
-- :fire: We don't guarantee stable APIs. They can still change until the official release
-- :fire: Integration against the upcoming release (currently `main` branch) is at your own risk
-
-## PRs to Categorize
-
-- [Bump minor version for release management](https://github.com/livingdocsIO/livingdocs-server/pull/9306)
-- [Bump minor version for release management](https://github.com/livingdocsIO/livingdocs-editor/pull/11037)
-- [Create usage log entries on publish](https://github.com/livingdocsIO/livingdocs-editor/pull/10945)
-- [Create usage log entries on publish](https://github.com/livingdocsIO/livingdocs-server/pull/9165)
-- [fix(media-library): actionbar positioning when closing sidepanel](https://github.com/livingdocsIO/livingdocs-editor/pull/11031)
-- [Remove li-target-length deprecated properties](https://github.com/livingdocsIO/livingdocs-server/pull/9287)
-- [Add GET endpoint to Public API for media library usage log](https://github.com/livingdocsIO/livingdocs-server/pull/9232)
-- [Public API `executeDocumentCommands` method returns public document version](https://github.com/livingdocsIO/livingdocs-server/pull/9191)
-- [Image Collections: Enable actions in collections and allow multiselect](https://github.com/livingdocsIO/livingdocs-editor/pull/10999)
-- [Drop support for deprecated li-target-length UI config properties](https://github.com/livingdocsIO/livingdocs-editor/pull/11024)
-- [fix(named-crops): triggering auto save on sidepanel open](https://github.com/livingdocsIO/livingdocs-editor/pull/11022)
-- [fix(media-library): extra search on image click](https://github.com/livingdocsIO/livingdocs-editor/pull/11023)
-- [Make livingdocs work with ignore-scripts=true to prevent supply chain attacks](https://github.com/livingdocsIO/livingdocs-server/pull/9245)
-- [Fix ajv string format for comma separated ids](https://github.com/livingdocsIO/livingdocs-server/pull/9265)
-- [Support quality, lossless and nearLossless options for webp images](https://github.com/livingdocsIO/livingdocs-server/pull/9258)
-- [Upgrade to @livingdocs/fastify-webpack@5.1.1](https://github.com/livingdocsIO/livingdocs-editor/pull/11014)
-- [Upgrade to @livingdocs/framework that doesn't load jquery and jsdom on the server](https://github.com/livingdocsIO/livingdocs-server/pull/9250)
-- [Image Collections upload drag and drop](https://github.com/livingdocsIO/livingdocs-editor/pull/10954)
-- [Image Collections: inject built-in liImageCollection content type + creationflow when writing project config](https://github.com/livingdocsIO/livingdocs-server/pull/9236)
-- [Image Collections: Distinct between Document Inbox and Image Collections](https://github.com/livingdocsIO/livingdocs-editor/pull/10969)
-- [Image Collections: Distinct between Document Inbox and Image Collections](https://github.com/livingdocsIO/livingdocs-server/pull/9215)
-- [fix(deps): update dependency file-type from 21.3.4 to v22 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/9126)
-- [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-server/pull/9238)
-- [Make poster image dashboards in li-poster-image and li-video-reference configurable](https://github.com/livingdocsIO/livingdocs-editor/pull/10944)
-- [Make poster image dashboards in li-poster-image and li-video-reference configurable](https://github.com/livingdocsIO/livingdocs-server/pull/9164)
-- [fix(deps): update opentelemetry (main) (minor)](https://github.com/livingdocsIO/livingdocs-server/pull/9244)
-- [Show editable properties in the properties panel for editable teasers](https://github.com/livingdocsIO/livingdocs-editor/pull/10975)
-
-- [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-server/pull/9227)
-- [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-editor/pull/10980)
-- [fix(deps): update dependency @livingdocs/framework from 33.0.3 to v33.0.4 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/9223)
-- [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-server/pull/9203)
-- [fix(deps): update dependency @livingdocs/framework from 33.0.3 to v33.0.4 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/10976)
-- [fix(ld panel title): Collapse indicator position](https://github.com/livingdocsIO/livingdocs-editor/pull/10963)
-- [fix(navigation): Chevron spacing on mobile](https://github.com/livingdocsIO/livingdocs-editor/pull/10959)
-- [Add 2026-05 version support to Public API](https://github.com/livingdocsIO/livingdocs-server/pull/9190)
-- [Pass `ttl` to `set` method of TTLCache in an object to prevent error in latest versions](https://github.com/livingdocsIO/livingdocs-server/pull/9176)
-- [Remove `editMode: 'default'` fallback value from project config](https://github.com/livingdocsIO/livingdocs-editor/pull/10943)
-- [Remove `editMode: 'default'` fallback value from project config](https://github.com/livingdocsIO/livingdocs-server/pull/9163)
-- [Check type consistency of usage log purpose `paramsSchema` entries](https://github.com/livingdocsIO/livingdocs-server/pull/9162)
-- [Add Norwegian Translations](https://github.com/livingdocsIO/livingdocs-editor/pull/10892)
-- [fix(media cards): Top Info](https://github.com/livingdocsIO/livingdocs-editor/pull/10942)
-- [fix(deps): update dependency pusher-js from 8.4.3 to v8.5.0 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/10941)
-- [Rename colliding deprecation messages](https://github.com/livingdocsIO/livingdocs-server/pull/9156)
-- [Tabs in media library sidepanels](https://github.com/livingdocsIO/livingdocs-editor/pull/10931)
-- [Export media library entry usage log to CSV](https://github.com/livingdocsIO/livingdocs-editor/pull/10936)
-- [Expose Usage Log Commands in Public API](https://github.com/livingdocsIO/livingdocs-server/pull/9144)
-- [Fix validation of confirmed usage log entries](https://github.com/livingdocsIO/livingdocs-server/pull/9145)
-- [Fix display filters on multi-source side panel](https://github.com/livingdocsIO/livingdocs-editor/pull/10915)
-- [Open lightbox with image locale used for thumbnail](https://github.com/livingdocsIO/livingdocs-editor/pull/10917)
-- [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-editor/pull/10927)
-- [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-server/pull/9143)
-- [Handle SVG files above 10MB](https://github.com/livingdocsIO/livingdocs-server/pull/9122)
-- [Enable multi-select in side panels](https://github.com/livingdocsIO/livingdocs-editor/pull/10914)
-- [chore(deps): update aws-sdk from 3.1015.0 to v3.1017.0 (main) (minor)](https://github.com/livingdocsIO/livingdocs-server/pull/9113)
-- [Fix selection mode by removing unused scrollPosition property](https://github.com/livingdocsIO/livingdocs-editor/pull/10910)
-- [fix(deps): update dependency @livingdocs/framework from 33.0.2 to v33.0.3 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/9114)
-- [fix(deps): update dependency @livingdocs/framework from 33.0.2 to v33.0.3 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/10909)
-- [Keep comments component link on transformed documents](https://github.com/livingdocsIO/livingdocs-editor/pull/9743)
-- [fix(deps): update dependency @livingdocs/framework from 32.13.4 to v33 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/9108)
-- [Clear localStorage to prevent cross-test contamination](https://github.com/livingdocsIO/livingdocs-editor/pull/10902)
-- [Add playwright tests for media library card configs](https://github.com/livingdocsIO/livingdocs-editor/pull/10376)
-- [fix(deps): update dependency @livingdocs/framework from 33.0.0 to v33.0.2 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/10900)
-- [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-server/pull/9101)
-- [Add vue-template-compiler to dependencies](https://github.com/livingdocsIO/livingdocs-editor/pull/10896)
-- [Fix image proposals in assistants](https://github.com/livingdocsIO/livingdocs-editor/pull/10867)
-- [chore(deps): update dependency puppeteer-core from 24.39.1 to v24.40.0 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/10891)
-- [Restrict image processing settings for use2025Behavior](https://github.com/livingdocsIO/livingdocs-server/pull/9047)
-- [Do not expose maxDimension if use2025Behavior is enabled](https://github.com/livingdocsIO/livingdocs-server/pull/9046)
-- [fix(deps): update dependency entities from 7.0.1 to v8 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/9084)
-- [fix(deps): update dependency pusher-js from 8.4.0 to v8.4.2 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/10886)
-- [Refactor migrations API](https://github.com/livingdocsIO/livingdocs-server/pull/9056)
-- [fix(deps): update dependency @livingdocs/framework from 32.13.1 to v32.13.4 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/9080)
-- [fix(deps): update dependency @livingdocs/framework from 32.13.3 to v32.13.4 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/10885)
-- [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-server/pull/9069)
-- [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-editor/pull/10880)
-- [fix(deps): update dependency @livingdocs/framework from 32.13.1 to v32.13.3 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/10876)
-- [Update vulnerable server dependencies](https://github.com/livingdocsIO/livingdocs-editor/pull/10874)
-- [Request confirmation before archiving a group](https://github.com/livingdocsIO/livingdocs-editor/pull/10870)
-- [chore(deps): update dependency exifreader from 4.36.2 to v4.37.0 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/9050)
-- [Prevent unexpected scroll jumps](https://github.com/livingdocsIO/livingdocs-editor/pull/10855)
-- [chore(deps): update aws-sdk from 3.1005.0 to v3.1007.0 (main) (minor)](https://github.com/livingdocsIO/livingdocs-server/pull/9044)
-- [chore(deps): update dependency sass from 1.97.3 to v1.98.0 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/10858)
-- [fix(image-collections): remove custom desktop / mobile labels for simplicity reasons](https://github.com/livingdocsIO/livingdocs-server/pull/9030)
-
-- [fix(app navigation): Line wrapping](https://github.com/livingdocsIO/livingdocs-editor/pull/10849)
-- [Migrate canvas to vue](https://github.com/livingdocsIO/livingdocs-editor/pull/10769)
-- [chore(deps): update dependency babel-loader from 10.0.0 to v10.1.0 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/10848)
-- [Feat preserve updated at](https://github.com/livingdocsIO/livingdocs-server/pull/9003)
-- [Fix: correct wrong dimensions in DB for rotated images](https://github.com/livingdocsIO/livingdocs-server/pull/8921)
-- [Fix check if image collections are enabled](https://github.com/livingdocsIO/livingdocs-editor/pull/10838)
-- [Prevent onDrag error](https://github.com/livingdocsIO/livingdocs-editor/pull/10839)
-- [Add script for migrating image modifications to variants](https://github.com/livingdocsIO/livingdocs-server/pull/9013)
-- [Show image toolbar button as active when the panel is open](https://github.com/livingdocsIO/livingdocs-editor/pull/10834)
-- [chore(deps): update dependency pg from 8.19.0 to v8.20.0 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/9020)
-- [fix(deps): update opentelemetry (main) (minor)](https://github.com/livingdocsIO/livingdocs-server/pull/9012)
-- [Allow gifs with 1800 frames](https://github.com/livingdocsIO/livingdocs-editor/pull/10824)
-- [Allow gifs with 1800 frames](https://github.com/livingdocsIO/livingdocs-server/pull/9002)
-- [fix(deps): update dependency copy-webpack-plugin from 13.0.1 to v14 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/10816)
-- [Sort completed tasks on task screen by completed date](https://github.com/livingdocsIO/livingdocs-editor/pull/10814)
-- [Fix task boards load more button not showing](https://github.com/livingdocsIO/livingdocs-editor/pull/10817)
-- [chore(deps): update dependency ioredis from 5.9.3 to v5.10.0 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/8998)
-- [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-editor/pull/10808)
-- [Improvements for image collections](https://github.com/livingdocsIO/livingdocs-editor/pull/10780)
-- [Limit search query length and display understandable error](https://github.com/livingdocsIO/livingdocs-editor/pull/10794)
-- [Fix undefined property error in user needs form](https://github.com/livingdocsIO/livingdocs-editor/pull/10800)
-- [fix(deps): update dependency c8 from 10.1.3 to v11 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/8989)
-- [fix(deps): update dependency @livingdocs/framework from 32.13.0 to v32.13.1 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/10798)
-- [Fix Multiselect Selection Navigation in Sidepanel](https://github.com/livingdocsIO/livingdocs-editor/pull/10787)
-- [Reset additional language after translation deletion](https://github.com/livingdocsIO/livingdocs-editor/pull/10788)
-- [Delete data record translation](https://github.com/livingdocsIO/livingdocs-editor/pull/10783)
-- [chore(deps): update aws-sdk from 3.996.0 to v3.997.0 (main) (minor)](https://github.com/livingdocsIO/livingdocs-server/pull/8981)
-- [Prevent image editor save button from overflowing](https://github.com/livingdocsIO/livingdocs-editor/pull/10781)
-
-To get an overview about new functionality, read the [Release Notes](TODO).
+To get an overview about new functionality, read the [Release Notes](https://livingdocs.io/en/release-may-2026).
 To learn about the necessary actions to update Livingdocs to `release-2026-05`, read on.
 
 **Attention:** If you skipped one or more releases, please also check the release-notes of the skipped ones.
@@ -264,6 +139,22 @@ To fix this example:
 
 - both page params would need to be either `li-text` or `li-integer`
 - or, one handle needs to be modified (e.g. renaming `page` to `webpage`)
+
+### Removal of `li-target-length` UI Config Properties :fire:
+
+The `allowAnyNumber`, `showExactCountCheckbox`, and `unit` properties inside `ui.config` of `li-target-length` and `li-system-target-length` metadata plugins have been removed. Please use `ui.config.mode` instead.
+
+### `@livingdocs/framework` No Longer Loads jQuery and JSDOM on the Server :fire:
+
+The `@livingdocs/framework` package no longer loads jQuery and JSDOM on the server. No behavior change is expected, but memory usage will decrease. Remove any code that relies on these being available as side effects of loading the framework.
+
+### `executeDocumentCommands` Returns Public Document Version :fire:
+
+From API version `2026-05` onward, the public API `executeDocumentCommands` method returns a public document version instead of the document write model. Pass `apiVersion: '2026-05'` to your requests to opt in early.
+
+### Stricter Public API Versioning :fire:
+
+New functionality is now only available in new API version endpoints. Any additions made to older API versions will be removed — upgrade to at least the version where the change was introduced.
 
 ## Deprecations
 
@@ -513,6 +404,14 @@ Editors can select multiple assets and edit their metadata in a single combined 
 This feature is automatically available in all Media Center dashboards. No configuration required.
 
 For more information, see the [Batch Actions]({{< ref "/guides/media-library/batch-actions" >}}) documentation.
+
+### Norwegian UI Translations :gift:
+
+The Livingdocs Editor is now available in Norwegian. The translations are automatically applied when the browser language is set to Norwegian.
+
+### Reduce Supply Chain Attack Vector :gift:
+
+Livingdocs Server now supports running with `ignore-scripts=true` in npm. This prevents arbitrary scripts from running during package installation, reducing the attack surface for supply chain attacks.
 
 ## Vulnerability Patches
 


### PR DESCRIPTION
Implemented using the cleanup-trn Claude Code 

## Motivation

Cleanup of the technical release notes for release-2026-05.

## Changelog

**Release Notes Updates**
- Added 4 breaking changes: `li-target-length` UI config property removal, `@livingdocs/framework` no longer loads jQuery/JSDOM on server, `executeDocumentCommands` returns public document version, Stricter Public API Versioning
- Added 2 features: Norwegian UI Translations, Reduce Supply Chain Attack Vector
- No new migrations
- Removed all PRs from PRs to Categorize section
- Updated release link to https://livingdocs.io/en/release-may-2026
