### PR TITLE
Document important properties in news agency reports guide

### DIFF
--- a/content/guides/integrations/news-agencies.md
+++ b/content/guides/integrations/news-agencies.md
@@ -211,6 +211,13 @@ Additionally, you can create dashboards to display articles created from news ag
 
 Now you're ready to import news agency reports using the Import API. Since you'll import documents of type `liNewsAgencyReport`, it's important to know the supported metadata properties and content components of this content type (see above).
 
+Properties that are important for the import logic:
+
+- `systemName`: A `string` identifying your importer, e.g. `alephdam`.
+- `id`: A `string` identifying your resource on the external system. This Id should be unique, so that updates will be applied to the same report.
+- `checksum`: An arbitrary `string` which allows you to determine whether it's an update.
+- `contentType`: A `string`, which always contains the value `liNewsAgencyReport`.
+
 ```js
 POST /api/{{< api-version >}}/import/documents
 


### PR DESCRIPTION
Relations:

- Issue: n/a
- Related PR's: n/a

# Motivation

The news agencies integration guide was missing descriptions for the important properties used in the import logic. Readers had to infer their purpose from context.

# Changelog

Added descriptions for the `systemName`, `id`, `checksum`, and `contentType` properties in the news agency reports guide to clarify their role in the import logic.
