### PR TITLE
Communicate that patches are informational

### DIFF
--- a/content/operations/releases/_release-template.md
+++ b/content/operations/releases/_release-template.md
@@ -138,7 +138,7 @@ We are aware of the following vulnerabilities in the Livingdocs Editor:
 
 ## Patches
 
-Here is a list of all patches after the release has been announced.
+Patches typically fix bugs and apply improvements within the current release. Keeping your deployment up-to-date with the latest patch version means you benefit from those fixes. No explicit action is required per patch — bumping the version is enough.
 
 ### Livingdocs Server Patches
 

--- a/content/operations/releases/release-2026-05.md
+++ b/content/operations/releases/release-2026-05.md
@@ -462,7 +462,7 @@ We are aware of the following vulnerabilities in the Livingdocs Editor:
 
 ## Patches
 
-Here is a list of all patches after the release has been announced.
+Patches typically fix bugs and apply improvements within the current release. Keeping your deployment up-to-date with the latest patch version means you benefit from those fixes. No explicit action is required per patch — bumping the version is enough.
 
 ### Livingdocs Server Patches
 - [v301.1.16](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.16): chore(example-server): Add image read permissions to Readers group


### PR DESCRIPTION
## What & why

Part of splitting up https://github.com/livingdocsIO/documentation/pull/1156.

The `## Patches` section opened with "Here is a list of all patches after the release has been announced", which reads like the reader needs to act on each patch. Patches are informational — keeping current on the latest patch version is enough.

Replaces that intro with an explanation of the contract, and applies the same wording to `_release-template.md` so future releases inherit it.

Targets `main` directly; independent of the AI-parsable reformat PRs (#1161 / #1162) and the typo-fixes PR (#1163). Uses `fix()` so semantic-release ships a patch on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
