### PR TITLE
Render full TOC for release notes

### DIFF
--- a/themes/hugo-docs/assets/elements/table-of-contents.scss
+++ b/themes/hugo-docs/assets/elements/table-of-contents.scss
@@ -39,5 +39,9 @@
       @extend .section-label;
       @extend .section-label--table-of-contents;
     }
+
+    ul ul ul a {
+      @extend %font-xs;
+    }
   }
 }

--- a/themes/hugo-docs/layouts/release-notes/single.html
+++ b/themes/hugo-docs/layouts/release-notes/single.html
@@ -47,7 +47,7 @@
 {{ define "side" }}
   {{ if (ne (.Param "renderTOC") false) }}
     <div class="page__toc">
-      {{ .Page.Fragments.ToHTML 1 2 false }}
+      {{ .TableOfContents }}
     </div>
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Part of splitting up https://github.com/livingdocsIO/documentation/pull/1156.

Before:

<img width="2126" height="991" alt="image" src="https://github.com/user-attachments/assets/336a9526-3bef-4e1f-9d14-dfb7e7e452da" />

After:

<img width="2121" height="992" alt="image" src="https://github.com/user-attachments/assets/04ae6bf1-8dfe-4cff-87d5-703639da6780" />

The [skills](https://github.com/livingdocsIO/documentation/pull/1162) will remove the emojis from titles so it'll look a bit cleaner in the future. You could test with https://github.com/livingdocsIO/documentation/pull/1162.