### PR TITLE
Add hint about elasticsearch index recreate

### DIFF
--- a/content/operations/releases/release-2026-07.md
+++ b/content/operations/releases/release-2026-07.md
@@ -106,13 +106,24 @@ livingdocs-server migrate up
 
 #### Recreate the Elasticsearch indices
 
-This release adds Norwegian language support (Bokmål `nb` and Nynorsk `nn`) across the drafts, publications, and media library indices, and language-aware text fields plus a German decompounder to the media library. These require an Elasticsearch index recreation to activate:
-
-```sh
-livingdocs-server elasticsearch-index --recreate
-```
+This release adds Norwegian language support (Bokmål `nb` and Nynorsk `nn`) across the drafts, publications, and media library indices, and language-aware text fields plus a German decompounder to the media library.
 
 The change is backwards compatible: until the indices are recreated, the new language-specific fields are silently skipped and search keeps working as before.
+
+{{< info >}}
+To enable Norwegian language support, the affected Elasticsearch indices need to be
+recreated. This is not a quick operation:
+
+```sh
+livingdocs-server elasticsearch-index --recreate --handle=<type>
+```
+
+`--recreate` **deletes the existing index** and creates a fresh one, then repopulates it
+by re-indexing all documents in a **background job**. Depending on the number of documents,
+this can take a while to complete. Until the background indexer finishes, the index is
+incomplete and search returns partial results, so plan a maintenance window and run it per
+`--handle` (drafts, publications, media library).
+{{< /info >}}
 
 ### Rollback
 


### PR DESCRIPTION
## Motivation

The release-2026-07 Elasticsearch index recreation step read like a quick command. On production, `elasticsearch-index --recreate` **deletes** the index and repopulates it via a background re-indexing job, during which search returns partial results. Operators need to know this upfront so they plan a maintenance window instead of running it blindly.

## Changelog

- Move the "backwards compatible" note above the command so the reason to recreate comes first.
- Wrap the recreate command in an `{{< info >}}` box warning that `--recreate` deletes the index and repopulates it in a background job, returning partial results until it finishes.
- Add `--handle=<type>` to the example and advise running it per handle (drafts, publications, media library) within a maintenance window.
