### PR TITLE
Add July 2026 webinar recording and slides links to release notes

### DIFF
--- a/content/operations/releases/release-2026-07.md
+++ b/content/operations/releases/release-2026-07.md
@@ -61,8 +61,8 @@ To learn about the necessary actions to update Livingdocs to `release-2026-07`, 
 
 ## Webinar
 
-- Feature Webinar Recording: **TODO**
-- Feature Webinar Documentation: **TODO**
+- [Feature Webinar Recording](https://us02web.zoom.us/rec/share/Gbsv5C0Vd9125id-BgMzN53ZMNBaCU4E1Ya-eR2xx2X8EL6YKG5iqfY69OdRELpq.IbJTEF1xNHHzEsmP) | Passcode: `E?963bz#`
+- [Feature Webinar Slides](https://drive.google.com/file/d/1i-K9XAJb9L8AxvSrEjG5JB_fxLjCcB8J/view?usp=sharing)
 - [Release Newsletter Subscription](https://confirmsubscription.com/h/j/61B064416E79453D)
 
 ## System Requirements


### PR DESCRIPTION
Relations:

- Issue: n/a
- Related PRs: n/a

# Motivation

The July 2026 release notes had placeholder TODOs for the webinar links. This fills in the recorded feature webinar and the presentation slides so readers can access them from the release page.

# Changelog

- 🍬 **release-2026-07**: add the Feature Webinar Recording (Zoom, with passcode) and Feature Webinar Slides (Google Drive) links, replacing the TODO placeholders
