### PR TITLE
Only show h2 and h3 of TRN sections in TOC

### DIFF
--- a/themes/hugo-docs/assets/elements/table-of-contents.scss
+++ b/themes/hugo-docs/assets/elements/table-of-contents.scss
@@ -40,7 +40,7 @@
       @extend .section-label--table-of-contents;
     }
 
-    ul ul ul a {
+    ul ul a {
       @extend %font-xs;
     }
   }

--- a/themes/hugo-docs/layouts/release-notes/single.html
+++ b/themes/hugo-docs/layouts/release-notes/single.html
@@ -47,7 +47,7 @@
 {{ define "side" }}
   {{ if (ne (.Param "renderTOC") false) }}
     <div class="page__toc">
-      {{ .TableOfContents }}
+      {{ .Page.Fragments.ToHTML 2 3 false }}
     </div>
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Relations:
- Related PR: https://github.com/livingdocsIO/documentation/pull/1165

# Motivation

Before #1165 there was not enough detail, after #1165 there was too much. There is no need to show the Detect and Fix headings for example, so rendering the whole TOC was a step too far.

# Changelog

Before #1165:

<img width="396" height="402" alt="image" src="https://github.com/user-attachments/assets/0928c27a-cd42-4c5c-9985-24a3834e046f" />

After #1165:

<img width="396" height="1269" alt="image" src="https://github.com/user-attachments/assets/a6c57834-d0d1-4396-8a6d-6be7de53ed79" />

Now:

<img width="396" height="1269" alt="image" src="https://github.com/user-attachments/assets/cf022b8b-5607-45d3-be77-04433ba5bcb3" />

I've also dropped the h1 headings because they are not used. They caused an unnecessary `<ul>` element to wrap the TOC.