### PR TITLE
release-2026-09: Document Search Images by Usage Log Details

### DIFF
--- a/content/customising/advanced/editor-configuration/base-filter.md
+++ b/content/customising/advanced/editor-configuration/base-filter.md
@@ -24,7 +24,7 @@ At all these places, one can use the same query format, e.g.
 {key: 'contentType', term: 'regular'}
 ```
 
-Learn more about the filter queries format [here]({{< ref "/reference/public-api/publications/search-filters" >}})
+The query expressions and logical operators are documented in the [Search Filters Query DSL]({{< ref "/reference/public-api/publications/search-filters#query-expressions" >}}) reference. Base filters use the same structure, written as JavaScript objects.
 
 ## Filter Query Examples
 
@@ -90,6 +90,13 @@ This are all available `queryTypes` which can be used to form a filter query.
 
 // media library entry usage logs ({{< added-in "release-2026-03" >}})
 {key: 'usageLog.pendingUserIds', termPattern: '{{ userId }}'}
+
+// media library entry usage log details ({{< added-in "release-2026-09" >}})
+// all conditions must hold on the same usage log entry
+{key: 'usageLog', nested: [
+  {key: 'purpose', term: 'print'},
+  {key: 'publicationDate', range: {gte: 'now-2y'}}
+]}
 ```
 
 ### Example - Filter by metadata with key/value

--- a/content/customising/advanced/editor-configuration/expert-search.md
+++ b/content/customising/advanced/editor-configuration/expert-search.md
@@ -107,6 +107,53 @@ Negate the contained expression.
 }
 ```
 
+## Nested
+
+{{< added-in "release-2026-09" block >}}
+
+Some fields hold a list of sub-objects, where each entry has its own set of properties. The clearest example is a media library entry's usage log: one image can have many usage log entries, each with its own `purpose`, `state`, `publicationDate`, and per-purpose `params`. A `nested` block matches when a **single** entry satisfies all of its conditions at once, so criteria that belong together are not accidentally spread across different entries.
+
+```json
+{
+  "key": "usageLog",
+  "nested": [
+    {"key": "purpose", "term": "print"},
+    {"key": "publicationDate", "range": {"gte": "now-2y"}}
+  ]
+}
+```
+
+This matches images that have at least one usage log entry whose purpose is `print` and whose publication date is within the last two years. Sub-keys are resolved relative to the nested field, so `purpose` refers to `usageLog.purpose`.
+
+The `nested` value can also be a logical operator, so entry conditions can be combined with `and`, `or`, or `not`:
+
+```json
+{
+  "not": {
+    "key": "usageLog",
+    "nested": [{"key": "purpose", "term": "socialMedia"}]
+  }
+}
+```
+
+This matches images that were never used for the `socialMedia` purpose.
+
+A nested block combines with normal top-level conditions like any other expression:
+
+```json
+{
+  "and": [
+    {"key": "mediaType", "term": "image"},
+    {"key": "usageLog", "nested": [
+      {"key": "state", "term": "confirmed"},
+      {"key": "params.date", "range": {"gte": "2026-01-01", "lte": "2026-12-31"}}
+    ]}
+  ]
+}
+```
+
+Which usage log fields are indexed, and how to make per-purpose `params` searchable, is described in the [Usage Log]({{< ref "/guides/media-library/media-library-setup/#searching-by-usage-log-details" >}}) guide.
+
 ## Example
 
 Logical operators and query expressions can be combined into more complex queries. A top-level array is treated as an AND.

--- a/content/customising/advanced/editor-configuration/expert-search.md
+++ b/content/customising/advanced/editor-configuration/expert-search.md
@@ -21,142 +21,9 @@ Add `liExpertSearch` to a dashboard's `displayFilters`:
 }
 ```
 
-## Query Expressions
+## Filter Expressions
 
-A query expression targets a single field via its `key` and one of the operators below.
-
-### Term
-
-An exact value match.
-
-```json
-{
-  "key": "metadata.title",
-  "term": "My Title"
-}
-```
-
-An array behaves like an OR over the values.
-
-```json
-{
-  "key": "metadata.language.locale",
-  "term": ["de", "fr"]
-}
-```
-
-### Range
-
-Match within a range. Any of `gt`, `gte`, `lt`, `lte` can be combined.
-
-```json
-{
-  "key": "metadata.count",
-  "range": {"gt": 1, "lt": 5}
-}
-```
-
-### Exists
-
-Check whether a property is set.
-
-```json
-{
-  "key": "metadata.teaserImage.mediaId",
-  "exists": true
-}
-```
-
-## Logical Operators
-
-Logical operators group expressions and change the default AND behaviour. Each operator takes an object or an array containing expressions or nested operators.
-
-### AND
-
-All conditions must match.
-
-```json
-{
-  "and": [
-    {"key": "metadata.news", "term": true},
-    {"key": "metadata.teaserImage.mediaId", "exists": false}
-  ]
-}
-```
-
-### OR
-
-Any condition may match.
-
-```json
-{
-  "or": [
-    {"key": "metadata.image.mediaId", "exists": true},
-    {"key": "metadata.teaserImage.mediaId", "exists": true}
-  ]
-}
-```
-
-### NOT
-
-Negate the contained expression.
-
-```json
-{
-  "not": {"key": "metadata.language.locale", "term": "de"}
-}
-```
-
-## Nested
-
-{{< added-in "release-2026-09" block >}}
-
-Some fields hold a list of sub-objects, where each entry has its own set of properties. The clearest example is a media library entry's usage log: one image can have many usage log entries, each with its own `purpose`, `state`, `publicationDate`, and per-purpose `params`. A `nested` block matches when a **single** entry satisfies all of its conditions at once, so criteria that belong together are not accidentally spread across different entries.
-
-```json
-{
-  "key": "usageLog",
-  "nested": [
-    {"key": "purpose", "term": "print"},
-    {"key": "publicationDate", "range": {"gte": "now-2y"}}
-  ]
-}
-```
-
-This matches images that have at least one usage log entry whose purpose is `print` and whose publication date is within the last two years. Sub-keys are resolved relative to the nested field, so `purpose` refers to `usageLog.purpose`.
-
-The `nested` value can also be a logical operator, so entry conditions can be combined with `and`, `or`, or `not`:
-
-```json
-{
-  "not": {
-    "key": "usageLog",
-    "nested": [{"key": "purpose", "term": "socialMedia"}]
-  }
-}
-```
-
-This matches images that were never used for the `socialMedia` purpose.
-
-A nested block combines with normal top-level conditions like any other expression:
-
-```json
-{
-  "and": [
-    {"key": "mediaType", "term": "image"},
-    {"key": "usageLog", "nested": [
-      {"key": "state", "term": "confirmed"},
-      {"key": "params.date", "range": {"gte": "2026-01-01", "lte": "2026-12-31"}}
-    ]}
-  ]
-}
-```
-
-Which usage log fields are indexed, and how to make per-purpose `params` searchable, is described in the [Usage Log]({{< ref "/guides/media-library/media-library-setup/#searching-by-usage-log-details" >}}) guide.
-
-## Example
-
-Logical operators and query expressions can be combined into more complex queries. A top-level array is treated as an AND.
+Expert Search uses the [Search Filters Query DSL]({{< ref "/reference/public-api/publications/search-filters#query-expressions" >}}). Every query expression and logical operator documented there is available, written as JSON with quoted keys and double-quoted strings.
 
 ```json
 {
@@ -172,3 +39,23 @@ Logical operators and query expressions can be combined into more complex querie
   ]
 }
 ```
+
+A top-level array is treated as an AND.
+
+### Searching nested fields
+
+{{< added-in "release-2026-09" block >}}
+
+The [`nested`]({{< ref "/reference/public-api/publications/search-filters#nested" >}}) operator matches a list of sub-objects, such as a media library entry's usage log, where several conditions must hold on the same entry.
+
+```json
+{
+  "key": "usageLog",
+  "nested": [
+    {"key": "purpose", "term": "print"},
+    {"key": "publicationDate", "range": {"gte": "now-2y"}}
+  ]
+}
+```
+
+Which usage log fields are indexed, and how to make per-purpose `params` searchable, is described in the [Usage Log]({{< ref "/guides/media-library/media-library-setup/#searching-by-usage-log-details" >}}) guide.

--- a/content/guides/media-library/media-library-setup/index.md
+++ b/content/guides/media-library/media-library-setup/index.md
@@ -845,6 +845,51 @@ The purposes are displayed to a user when creating or updating a usage log entry
 
 Usage log purposes can be flagged as internal. When the `internal` property is set to `true` it prevents a user from creating, updating or deleting entries for the purpose within the editor. A read-only entry will still be visible within the UI. This is intended for purposes whose entries are created automatically on publish through a [`recordUsageLogEntry` function]({{< ref "#generating-usage-log-entries-on-publish" >}}).
 
+### Searching by usage log details
+
+{{< added-in "release-2026-09" block >}}
+
+Every usage log entry is indexed individually, so media library searches and dashboard filters can match images by what is in their usage log, and combine several criteria that must all hold on the *same* entry. Typical questions this answers are "used in print within the last two years" or "a confirmed social-media usage in 2026".
+
+The following fields of each entry are indexed: `state`, `purpose`, `reportingDate`, `userId`, `documentId`, `publicationDate`, `publicationId`, and `url`. Both pending and confirmed entries are indexed.
+
+To also search by a purpose's custom `params`, set `config: { index: true }` on the `paramsSchema` property. Only indexed params are queryable, and each keeps its type, so it supports the matching operators of its metadata plugin (for example a `range` on a `li-date` param).
+
+```js
+{
+  mediaCenter: {
+    usagePurposes: [
+      {
+        handle: 'print',
+        label: {en: 'Print', de: 'Druck'},
+        paramsSchema: [
+          {
+            handle: 'department',
+            type: 'li-text',
+            config: {
+              index: true // makes the usage log param searchable
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Query the indexed entries with the `nested` filter operator, either in a dashboard's `baseFilters` or in the [Expert Search]({{< ref "/customising/advanced/editor-configuration/expert-search/#nested" >}}) display filter. Sub-keys inside a `nested` block are resolved against the entry, and `usageLog` works as an alias for the underlying `usageLogV2` field.
+
+```js
+baseFilters: [
+  {key: 'usageLog', nested: [
+    {key: 'purpose', term: 'print'},
+    {key: 'publicationDate', range: {gte: 'now-2y'}}
+  ]}
+]
+```
+
+The new fields are added by a media library reindex. Run `livingdocs-server elasticsearch-index --handle=li-media` after upgrading so existing entries gain the usage log fields. The mapping is patched in place, so no `--recreate` is needed.
+
 ### Creating usage log dashboards
 
 It's possible to define dashboards which provide an easy way to review incomplete entries:

--- a/content/guides/media-library/media-library-setup/index.md
+++ b/content/guides/media-library/media-library-setup/index.md
@@ -893,18 +893,6 @@ baseFilters: [
 ]
 ```
 
-{{< warning >}}
-The new fields are added by a media library reindex. Run the following after upgrading so existing entries gain the usage log fields:
-
-```
-livingdocs-server elasticsearch-index --handle=li-media
-```
-
-The `usageLogBilledEntryDates` and `usageLogUnresolvedBillingEntryDates` display filters now compile to nested queries as well, so they return no results until the reindex has run.
-
-The mapping is patched in place, so no `--recreate` is needed. A `--recreate` is only necessary if the mapping patch is rejected as incompatible.
-{{< /warning >}}
-
 ### Creating usage log dashboards
 
 It's possible to define dashboards which provide an easy way to review incomplete entries:

--- a/content/guides/media-library/media-library-setup/index.md
+++ b/content/guides/media-library/media-library-setup/index.md
@@ -822,6 +822,51 @@ The purposes are displayed to a user when creating or updating a usage log entry
 
 Usage log purposes can be flagged as internal. When the `internal` property is set to `true` it prevents a user from creating, updating or deleting entries for the purpose within the editor. A read-only entry will still be visible within the UI. This is intended for purposes whose entries are created automatically on publish through a [`recordUsageLogEntry` function]({{< ref "#generating-usage-log-entries-on-publish" >}}).
 
+### Searching by usage log details
+
+{{< added-in "release-2026-09" block >}}
+
+Every usage log entry is indexed individually, so media library searches and dashboard filters can match images by what is in their usage log, and combine several criteria that must all hold on the *same* entry. Typical questions this answers are "used in print within the last two years" or "a confirmed social-media usage in 2026".
+
+The following fields of each entry are indexed: `state`, `purpose`, `reportingDate`, `userId`, `documentId`, `publicationDate`, `publicationId`, and `url`. Both pending and confirmed entries are indexed.
+
+To also search by a purpose's custom `params`, set `config: { index: true }` on the `paramsSchema` property. Only indexed params are queryable, and each keeps its type, so it supports the matching operators of its metadata plugin (for example a `range` on a `li-date` param).
+
+```js
+{
+  mediaCenter: {
+    usagePurposes: [
+      {
+        handle: 'print',
+        label: {en: 'Print', de: 'Druck'},
+        paramsSchema: [
+          {
+            handle: 'department',
+            type: 'li-text',
+            config: {
+              index: true // makes the usage log param searchable
+            }
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Query the indexed entries with the `nested` filter operator, either in a dashboard's `baseFilters` or in the [Expert Search]({{< ref "/customising/advanced/editor-configuration/expert-search/#nested" >}}) display filter. Sub-keys inside a `nested` block are resolved against the entry, and `usageLog` works as an alias for the underlying `usageLogV2` field.
+
+```js
+baseFilters: [
+  {key: 'usageLog', nested: [
+    {key: 'purpose', term: 'print'},
+    {key: 'publicationDate', range: {gte: 'now-2y'}}
+  ]}
+]
+```
+
+The new fields are added by a media library reindex. Run `livingdocs-server elasticsearch-index --handle=li-media` after upgrading so existing entries gain the usage log fields. The mapping is patched in place, so no `--recreate` is needed.
+
 ### Creating usage log dashboards
 
 It's possible to define dashboards which provide an easy way to review incomplete entries:

--- a/content/guides/media-library/media-library-setup/index.md
+++ b/content/guides/media-library/media-library-setup/index.md
@@ -828,7 +828,9 @@ Usage log purposes can be flagged as internal. When the `internal` property is s
 
 Every usage log entry is indexed individually, so media library searches and dashboard filters can match images by what is in their usage log, and combine several criteria that must all hold on the *same* entry. Typical questions this answers are "used in print within the last two years" or "a confirmed social-media usage in 2026".
 
-The following fields of each entry are indexed: `state`, `purpose`, `reportingDate`, `userId`, `documentId`, `publicationDate`, `publicationId`, and `url`. Both pending and confirmed entries are indexed.
+The following fields of each entry are indexed: `state`, `purpose`, `reportingDate`, `userId`, `documentId`, `publicationDate`, `publicationId`, `url`, and `billing`. Both pending and confirmed entries are indexed.
+
+Date fields support `range` queries, `billing` is a boolean, and the remaining fields match on exact values.
 
 To also search by a purpose's custom `params`, set `config: { index: true }` on the `paramsSchema` property. Only indexed params are queryable, and each keeps its type, so it supports the matching operators of its metadata plugin (for example a `range` on a `li-date` param).
 
@@ -854,7 +856,9 @@ To also search by a purpose's custom `params`, set `config: { index: true }` on 
 }
 ```
 
-Query the indexed entries with the `nested` filter operator, either in a dashboard's `baseFilters` or in the [Expert Search]({{< ref "/customising/advanced/editor-configuration/expert-search/#nested" >}}) display filter. Sub-keys inside a `nested` block are resolved against the entry, and `usageLog` works as an alias for the underlying `usageLogV2` field.
+Query the indexed entries with the [`nested`]({{< ref "/reference/public-api/publications/search-filters#nested" >}}) filter operator, either in a dashboard's `baseFilters` or in the [Expert Search]({{< ref "/customising/advanced/editor-configuration/expert-search/#searching-nested-fields" >}}) display filter. Sub-keys inside a `nested` block are resolved against the entry, and `usageLog` works as an alias for the underlying `usageLogEntries` field.
+
+A `nested` block is the only way to reach these fields. Usage log conditions written as plain top-level keys do not resolve against the indexed entries.
 
 ```js
 baseFilters: [
@@ -865,7 +869,41 @@ baseFilters: [
 ]
 ```
 
-The new fields are added by a media library reindex. Run `livingdocs-server elasticsearch-index --handle=li-media` after upgrading so existing entries gain the usage log fields. The mapping is patched in place, so no `--recreate` is needed.
+A list inside `nested` is an implicit AND, so the conditions above must hold on one and the same entry. To express anything else, pass a logical operator instead of a list. The example below answers "which photos ran in the politics department in print in the last year", combining built-in fields with two indexed `params`.
+
+```js
+baseFilters: [
+  {key: 'usageLog', nested: [
+    {key: 'state', term: 'confirmed'},
+    {key: 'params.medium', term: 'print'},
+    {key: 'params.department', term: 'politik'},
+    {key: 'publicationDate', range: {gte: 'now-1y'}}
+  ]}
+]
+```
+
+Wrapping a nested block in `not` matches entries that have no such usage at all, which is how questions like "not used online in the past two years" are expressed.
+
+```js
+baseFilters: [
+  {not: {key: 'usageLog', nested: [
+    {key: 'purpose', term: 'online'},
+    {key: 'publicationDate', range: {gte: 'now-2y'}}
+  ]}}
+]
+```
+
+{{< warning >}}
+The new fields are added by a media library reindex. Run the following after upgrading so existing entries gain the usage log fields:
+
+```
+livingdocs-server elasticsearch-index --handle=li-media
+```
+
+The `usageLogBilledEntryDates` and `usageLogUnresolvedBillingEntryDates` display filters now compile to nested queries as well, so they return no results until the reindex has run.
+
+The mapping is patched in place, so no `--recreate` is needed. A `--recreate` is only necessary if the mapping patch is rejected as incompatible.
+{{< /warning >}}
 
 ### Creating usage log dashboards
 

--- a/content/guides/media-library/media-library-setup/index.md
+++ b/content/guides/media-library/media-library-setup/index.md
@@ -856,7 +856,7 @@ To also search by a purpose's custom `params`, set `config: { index: true }` on 
 }
 ```
 
-Query the indexed entries with the [`nested`]({{< ref "/reference/public-api/publications/search-filters#nested" >}}) filter operator, either in a dashboard's `baseFilters` or in the [Expert Search]({{< ref "/customising/advanced/editor-configuration/expert-search/#searching-nested-fields" >}}) display filter. Sub-keys inside a `nested` block are resolved against the entry, and `usageLog` works as an alias for the underlying `usageLogEntries` field.
+Query the indexed entries with the [`nested`]({{< ref "/reference/public-api/publications/search-filters#nested" >}}) filter operator, either in a dashboard's `baseFilters` or in the [Expert Search]({{< ref "/customising/advanced/editor-configuration/expert-search/#searching-nested-fields" >}}) display filter. Use `usageLog` as the key, and sub-keys inside the `nested` block are resolved against a single entry.
 
 A `nested` block is the only way to reach these fields. Usage log conditions written as plain top-level keys do not resolve against the indexed entries.
 

--- a/content/operations/releases/release-2026-09.md
+++ b/content/operations/releases/release-2026-09.md
@@ -159,6 +159,32 @@ No rollback steps are required for this release.
 
 ## Features :gift:
 
+### Search Images by Usage Log Details
+
+For newsrooms that run the Media Center as a full DAM, the usage log holds the answers to questions like "which images ran in print in the last two years" or "whose usages still need billing this month". Editors can now search the media library by the contents of the usage log, and combine several conditions that must all hold on the same usage entry.
+
+Each usage log entry is now indexed on its own, so a query can match one entry by its purpose, state, dates, user, and any custom params at the same time. Searches run from a dashboard's base filters or from the Expert Search field.
+
+A new `nested` filter operator ties conditions to a single usage log entry, instead of matching them loosely across all of an image's entries.
+
+```json
+{
+  "key": "usageLog",
+  "nested": [
+    {"key": "purpose", "term": "print"},
+    {"key": "publicationDate", "range": {"gte": "now-2y"}}
+  ]
+}
+```
+
+To search by a purpose's custom params, mark them with `config: { index: true }` in the `paramsSchema`.
+
+{{< info >}}
+The usage log fields are added by a media library reindex. Run `livingdocs-server elasticsearch-index --handle=li-media` after upgrading so existing entries become searchable. The mapping is patched in place, so no `--recreate` is needed.
+{{< /info >}}
+
+For more information, see the [Usage Log]({{< ref "/guides/media-library/media-library-setup/#searching-by-usage-log-details" >}}) and [Expert Search]({{< ref "/customising/advanced/editor-configuration/expert-search/#nested" >}}) documentation.
+
 ## Vulnerability Patches
 
 We are constantly patching module vulnerabilities for the Livingdocs Server and Livingdocs Editor as module fixes are available. Below is a list of all patched vulnerabilities included in the release.

--- a/content/operations/releases/release-2026-09.md
+++ b/content/operations/releases/release-2026-09.md
@@ -298,9 +298,9 @@ For more information, see the [Media Library]({{< ref "/guides/media-library/med
 
 ### Search Images by Usage Log Details
 
-For newsrooms that run the Media Center as a full DAM, the usage log holds the answers to questions like "which images ran in print in the last two years" or "whose usages still need billing this month". Editors can now search the media library by the contents of the usage log, and combine several conditions that must all hold on the same usage entry.
+An image's usage log records where and when it was used. Until now that information was not searchable: editors could filter by billing status, but not by the details that actually matter, such as "ran in print under politics" or "not used online in two years". Editors can now search the media library by the contents of the usage log, and get back the images themselves rather than a list of log entries.
 
-Each usage log entry is now indexed on its own, so a query can match one entry by its purpose, state, dates, user, and any custom params at the same time. Searches run from a dashboard's base filters or from the Expert Search field.
+Every usage log entry is indexed on its own, so one query can match a single entry by its purpose, state, dates, user, billing flag, and any custom params at the same time. Searches run from a dashboard's base filters or from the Expert Search field.
 
 A new `nested` filter operator ties conditions to a single usage log entry, instead of matching them loosely across all of an image's entries.
 
@@ -318,9 +318,11 @@ To search by a purpose's custom params, mark them with `config: { index: true }`
 
 {{< info >}}
 The usage log fields are added by a media library reindex. Run `livingdocs-server elasticsearch-index --handle=li-media` after upgrading so existing entries become searchable. The mapping is patched in place, so no `--recreate` is needed.
+
+The existing `usageLogBilledEntryDates` and `usageLogUnresolvedBillingEntryDates` display filters now use nested queries too, so they return no results until the reindex has run.
 {{< /info >}}
 
-For more information, see the [Usage Log]({{< ref "/guides/media-library/media-library-setup/#searching-by-usage-log-details" >}}) and [Expert Search]({{< ref "/customising/advanced/editor-configuration/expert-search/#nested" >}}) documentation.
+For more information, see the [Usage Log]({{< ref "/guides/media-library/media-library-setup/#searching-by-usage-log-details" >}}), [Search Filters]({{< ref "/reference/public-api/publications/search-filters#nested" >}}) and [Expert Search]({{< ref "/customising/advanced/editor-configuration/expert-search" >}}) documentation.
 
 ## Vulnerability Patches
 

--- a/content/operations/releases/release-2026-09.md
+++ b/content/operations/releases/release-2026-09.md
@@ -296,6 +296,32 @@ The button appears on every Media Library dashboard and needs no configuration.
 
 For more information, see the [Media Library]({{< ref "/guides/media-library/media-library-setup/#result-count" >}}) documentation.
 
+### Search Images by Usage Log Details
+
+For newsrooms that run the Media Center as a full DAM, the usage log holds the answers to questions like "which images ran in print in the last two years" or "whose usages still need billing this month". Editors can now search the media library by the contents of the usage log, and combine several conditions that must all hold on the same usage entry.
+
+Each usage log entry is now indexed on its own, so a query can match one entry by its purpose, state, dates, user, and any custom params at the same time. Searches run from a dashboard's base filters or from the Expert Search field.
+
+A new `nested` filter operator ties conditions to a single usage log entry, instead of matching them loosely across all of an image's entries.
+
+```json
+{
+  "key": "usageLog",
+  "nested": [
+    {"key": "purpose", "term": "print"},
+    {"key": "publicationDate", "range": {"gte": "now-2y"}}
+  ]
+}
+```
+
+To search by a purpose's custom params, mark them with `config: { index: true }` in the `paramsSchema`.
+
+{{< info >}}
+The usage log fields are added by a media library reindex. Run `livingdocs-server elasticsearch-index --handle=li-media` after upgrading so existing entries become searchable. The mapping is patched in place, so no `--recreate` is needed.
+{{< /info >}}
+
+For more information, see the [Usage Log]({{< ref "/guides/media-library/media-library-setup/#searching-by-usage-log-details" >}}) and [Expert Search]({{< ref "/customising/advanced/editor-configuration/expert-search/#nested" >}}) documentation.
+
 ## Vulnerability Patches
 
 We are constantly patching module vulnerabilities for the Livingdocs Server and Livingdocs Editor as module fixes are available. Below is a list of all patched vulnerabilities included in the release.

--- a/content/reference/public-api/publications/search-filters.md
+++ b/content/reference/public-api/publications/search-filters.md
@@ -8,6 +8,17 @@ menus:
 
 Search filters can be used to filter documents using a custom query DSL.
 
+The same DSL is used in several places. The structure is identical everywhere, only the literal syntax differs:
+
+| Where                                                 | Context                                                                                               | Syntax            |
+| :---------------------------------------------------- | :---------------------------------------------------------------------------------------------------- | :---------------- |
+| `filters` query parameter                             | Public API                                                                                            | JSON string       |
+| `baseFilters`, `defaultQueries`, `emptySearchQueries` | [Base Filter]({{< ref "/customising/advanced/editor-configuration/base-filter" >}}) project config     | JavaScript object |
+| `filter` property of a display filter                 | [Display Filter]({{< ref "/customising/advanced/editor-configuration/display-filter" >}}) definition   | JavaScript object |
+| Expert Search input                                   | [Expert Search]({{< ref "/customising/advanced/editor-configuration/expert-search" >}}) display filter | JSON              |
+
+The examples on this page are written as JavaScript objects. In the Public API and the Expert Search, write the same expressions as JSON, with quoted keys and double-quoted strings.
+
 ### Filter Fields
 
 | Property                        | Type    |
@@ -148,6 +159,51 @@ To negate multiple conditions nest another logical operator within.
   }
 }
 ```
+
+#### Nested
+
+{{< added-in "release-2026-09" block >}}
+
+Some fields hold a list of sub-objects, where each entry carries its own set of properties. A `nested` block matches when a **single** entry satisfies all of its conditions at once, so criteria that belong together are not spread across different entries of the same document.
+
+The clearest example is a media library entry's usage log: one image can have many usage log entries, each with its own `purpose`, `state`, `publicationDate` and per-purpose `params`.
+
+```js
+{
+  key: 'usageLog',
+  nested: [
+    {key: 'purpose', term: 'print'},
+    {key: 'publicationDate', range: {gte: 'now-2y'}}
+  ]
+}
+```
+
+This matches entries that have at least one usage log entry whose purpose is `print` and whose publication date is within the last two years. Sub-keys are resolved relative to the nested field, so `purpose` means `usageLog.purpose`.
+
+The `nested` value accepts the following forms:
+
+| Value                   | Meaning                    |
+| :---------------------- | :------------------------- |
+| Array                   | Implicit AND               |
+| `{and: [...]}`          | All conditions must match  |
+| `{or: [...]}`           | Any condition may match    |
+| `{not: {...}}`          | Negates the contained block |
+| `{key: ..., term: ...}` | A single condition         |
+
+Because a nested block is an expression like any other, it combines with top-level conditions and can be negated.
+
+```js
+{
+  and: [
+    {key: 'mediaType', term: 'image'},
+    {not: {key: 'usageLog', nested: [{key: 'purpose', term: 'socialMedia'}]}}
+  ]
+}
+```
+
+This matches images that were never used for the `socialMedia` purpose.
+
+Which fields of a media library usage log are indexed, and how to make per-purpose `params` searchable, is described in the [Usage Log]({{< ref "/guides/media-library/media-library-setup/#searching-by-usage-log-details" >}}) guide.
 
 ### Example
 


### PR DESCRIPTION
Documents the Search Images by Usage Log Details feature in the release-2026-09 TRN, and unifies the search filter DSL documentation so the grammar lives in one place.

## Changelog

- Document the `nested` operator in the Search Filters reference, including its value forms and how it combines with top-level conditions
- Remove the duplicated query expressions and logical operators from the Expert Search page, which now covers its configuration and UI behaviour and links to the reference
- Add a "where this DSL is used" table to the Search Filters reference, naming the syntax per context, since base filters and display filters are JavaScript objects while the Public API and Expert Search take JSON
- Link Base Filter to the same reference and add a nested usage log example to its catalogue
- Document searching by usage log details in the Media Library Setup guide, with the indexed fields, indexed `params`, and worked examples
- Add the Feature entry to release-2026-09

## Corrections to the first draft

- The draft named the internal field backing the usage log index. The docs now describe only the public `usageLog` key, so the storage detail stays free to change
- `billing` is indexed as well and was missing from the field list
- Usage log fields are reachable only inside a `nested` block
- The reindex is required before the existing `usageLogBilledEntryDates` and `usageLogUnresolvedBillingEntryDates` display filters return results again, which the draft did not mention

The four `LIDEP087` deprecations from the server PR are intentionally left out of this PR.

Relations:
- Related PRs:
  - https://github.com/livingdocsIO/livingdocs-server/pull/9764
  - https://github.com/livingdocsIO/livingdocs-editor/pull/11402

🤖 Generated with [Claude Code](https://claude.com/claude-code)