### PR TITLE
Fix incorrect state value in image/file/video import status docs

### DIFF
--- a/data/endpoints/import-files-status.yaml
+++ b/data/endpoints/import-files-status.yaml
@@ -27,7 +27,7 @@ responses:
         "id": "25bzj8j",
         "files": [
           {
-            "state": "success",
+            "state": "imported",
             "mediaId": "jjiwhsf23kdk",
             "systemName": "identifier-for-your-system",
             "externalId": "external-unique-id-123"
@@ -96,7 +96,7 @@ openapi:
                 state: success
                 id: 25bzj8j
                 files:
-                  - state: success
+                  - state: imported
                     mediaId: jjiwhsf23kdk
                     systemName: identifier-for-your-system
                     externalId: external-unique-id-123

--- a/data/endpoints/import-images-status.yaml
+++ b/data/endpoints/import-images-status.yaml
@@ -28,7 +28,7 @@ responses:
         "id": "25bzj8j",
         "images": [
           {
-            "state": "success",
+            "state": "imported",
             "externalId": "external-unique-id-123",
             "systemName": "identifier-for-your-system",
             "image": {
@@ -115,7 +115,7 @@ openapi:
                 state: success
                 id: 25bzj8j
                 images:
-                  - state: success
+                  - state: imported
                     externalId: external-unique-id-123
                     systemName: identifier-for-your-system
                     image:

--- a/data/endpoints/import-videos-status.yaml
+++ b/data/endpoints/import-videos-status.yaml
@@ -25,7 +25,7 @@ responses:
         "id": "25bzj8j",
         "videos": [
           {
-            "state": "success",
+            "state": "imported",
             "systemName": "identifier-for-your-system",
             "externalId": "external-unique-id-123",
             "video": {
@@ -104,7 +104,7 @@ openapi:
                 state: success
                 id: 25bzj8j
                 videos:
-                  - state: success
+                  - state: imported
                     systemName: identifier-for-your-system
                     externalId: external-unique-id-123
                     video:


### PR DESCRIPTION
Relations:

- [Issue: conversation with Slack](https://livingdocs.slack.com/archives/C03NXRHNVPS/p1786615065013549)
- Related PRs: n/a

# Motivation

The import-status endpoint docs for images, files, and videos showed an example where an individual entry's `state` is `"success"`. The server never returns that value for a single entry — per-entry `state` can only be `imported`, `skipped`, or `failed` (`success` is only ever the top-level/batch `state`). This corrects the misleading example across all three docs.

# Changelog

- 🐞 Fix incorrect example `state: success` for an individual entry in the image, file, and video import-status docs (`import-images-status.yaml`, `import-files-status.yaml`, `import-videos-status.yaml`) — corrected to `state: imported` to match actual server behavior
