### PR TITLE
fix(design assets files): Links updated

### DIFF
--- a/themes/hugo-docs/assets/base/typography.scss
+++ b/themes/hugo-docs/assets/base/typography.scss
@@ -33,7 +33,7 @@ h5 {
   }
 }
 
-$gitfiles: 'https://livingdocsio.github.io/livingdocs-design-assets/docs/site-2021';
+$gitfiles: 'https://livingdocsio.github.io/livingdocs-design-assets/docs/documentation';
 @font-face {
   font-family: li-Specialchars;
   src: url($gitfiles + '/fonts/li-specialchars.otf');

--- a/themes/hugo-docs/layouts/partials/footer.html
+++ b/themes/hugo-docs/layouts/partials/footer.html
@@ -6,7 +6,7 @@
         target="_blank"
       >
         <img
-          src="//livingdocsio.github.io/livingdocs-design-assets/docs/site-2021/icons/linkedin.svg"
+          src="//livingdocsio.github.io/livingdocs-design-assets/docs/documentation/icons/linkedin.svg"
         />
       </a>
     </li>
@@ -15,7 +15,7 @@
         href="https://x.com/livingdocsIO"
         target="_blank"
       >
-        <img src="//livingdocsio.github.io/livingdocs-design-assets/docs/site-2021/icons/x.svg" />
+        <img src="//livingdocsio.github.io/livingdocs-design-assets/docs/documentation/icons/x.svg" />
       </a>
     </li>
     <li>
@@ -24,7 +24,7 @@
         target="_blank"
       >
         <img
-          src="//livingdocsio.github.io/livingdocs-design-assets/docs/site-2021/icons/vimeo.svg"
+          src="//livingdocsio.github.io/livingdocs-design-assets/docs/documentation/icons/vimeo.svg"
         />
       </a>
     </li>
@@ -34,7 +34,7 @@
         target="_blank"
       >
         <img
-          src="//livingdocsio.github.io/livingdocs-design-assets/docs/site-2021/icons/github.svg"
+          src="//livingdocsio.github.io/livingdocs-design-assets/docs/documentation/icons/github.svg"
         />
       </a>
     </li>


### PR DESCRIPTION
Related PR: https://github.com/livingdocsIO/livingdocs-design-assets/pull/7

- Updated asset links to their new URLs after deleting 'site-2021' folder in the design-assets repo

Original file removal PR: https://github.com/livingdocsIO/livingdocs-design-assets/pull/5