### PR TITLE
Remove vulnerability warnings which were fixed by TuxCare packages

### DIFF
--- a/content/operations/releases/_release-template.md
+++ b/content/operations/releases/_release-template.md
@@ -130,11 +130,7 @@ This release we have patched the following vulnerabilities in the Livingdocs Edi
 
 - TBD
 
-We are aware of the following vulnerabilities in the Livingdocs Editor:
-
-- [CVE-2023-44270](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) vulnerability in `postcss`, it affects linters using PostCSS to parse external Cascading Style Sheets (CSS). It is not exploitable in the editor as we don't load untrusted external CSS at build time.
-- [CVE-2022-25844](https://github.com/advisories/GHSA-m2h2-264f-f486), [CVE-2022-25869](https://github.com/advisories/GHSA-prc3-vjfx-vhm9), [CVE-2023-26116](https://github.com/advisories/GHSA-2vrf-hf26-jrp5), [CVE-2023-26117](https://github.com/advisories/GHSA-2qqx-w9hr-q5gx), [CVE-2023-26118](https://github.com/advisories/GHSA-qwqh-hm9m-p5hr), [CVE-2024-8372](https://github.com/advisories/GHSA-m9gf-397r-hwpg), [CVE-2024-8373](https://github.com/advisories/GHSA-mqm9-c95h-x2p6), [CVE-2024-21490](https://github.com/advisories/GHSA-4w4v-5hc9-xrr2), [CVE-2025-0716](https://github.com/advisories/GHSA-j58c-ww9w-pwp5) are all AngularJS vulnerabilities that don't have a patch available. We are working on removing all AngularJS from our code and vulnerabilities will go away when we complete the transition to Vue.js.
-- [CVE-2024-9506](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx) vulnerability in `vue`, an ReDoS vulnerability exploitable through inefficient regex evaluation in parseHTML function. The issue can cause excessive CPU usage but is not exploitable in the editor as we don't load untrusted HTML at runtime.
+No known vulnerabilities. :tada:
 
 ## Patches
 

--- a/content/operations/releases/release-2026-03.md
+++ b/content/operations/releases/release-2026-03.md
@@ -340,18 +340,18 @@ This release we have patched the following vulnerabilities in the Livingdocs Edi
 - [CVE-2026-25639 / GHSA-43fc-jf86-j433](https://github.com/advisories/GHSA-43fc-jf86-j433) patched in axios v1.13.5
 - [CVE-2025-13465 / GHSA-xxjr-mmjv-4gpg](https://github.com/advisories/GHSA-xxjr-mmjv-4gpg) patched in lodash v4.17.23
 - [GHSA-73rr-hh4g-fpgx](https://github.com/kpdecker/jsdiff/security/advisories/GHSA-73rr-hh4g-fpgx) patched in diff v8.0.0
+- [CVE-2023-44270](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) patched in postcss v8.4.31
+- [CVE-2022-25844](https://github.com/advisories/GHSA-m2h2-264f-f486), [CVE-2022-25869](https://github.com/advisories/GHSA-prc3-vjfx-vhm9), [CVE-2023-26116](https://github.com/advisories/GHSA-2vrf-hf26-jrp5), [CVE-2023-26117](https://github.com/advisories/GHSA-2qqx-w9hr-q5gx), [CVE-2023-26118](https://github.com/advisories/GHSA-qwqh-hm9m-p5hr), [CVE-2024-8372](https://github.com/advisories/GHSA-m9gf-397r-hwpg), [CVE-2024-8373](https://github.com/advisories/GHSA-mqm9-c95h-x2p6), [CVE-2024-21490](https://github.com/advisories/GHSA-4w4v-5hc9-xrr2), [CVE-2025-0716](https://github.com/advisories/GHSA-j58c-ww9w-pwp5) all patched with TuxCare Long Term Support License for AngularJS
+- [CVE-2024-9506](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx) patched with TuxCare Long Term Support License for Vue
 
-We are aware of the following vulnerabilities in the Livingdocs Editor:
-
-- [CVE-2023-44270](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) vulnerability in `postcss`, it affects linters using PostCSS to parse external Cascading Style Sheets (CSS). It is not exploitable in the editor as we don't load untrusted external CSS at build time.
-- [CVE-2022-25844](https://github.com/advisories/GHSA-m2h2-264f-f486), [CVE-2022-25869](https://github.com/advisories/GHSA-prc3-vjfx-vhm9), [CVE-2023-26116](https://github.com/advisories/GHSA-2vrf-hf26-jrp5), [CVE-2023-26117](https://github.com/advisories/GHSA-2qqx-w9hr-q5gx), [CVE-2023-26118](https://github.com/advisories/GHSA-qwqh-hm9m-p5hr), [CVE-2024-8372](https://github.com/advisories/GHSA-m9gf-397r-hwpg), [CVE-2024-8373](https://github.com/advisories/GHSA-mqm9-c95h-x2p6), [CVE-2024-21490](https://github.com/advisories/GHSA-4w4v-5hc9-xrr2), [CVE-2025-0716](https://github.com/advisories/GHSA-j58c-ww9w-pwp5) are all AngularJS vulnerabilities that don't have a patch available. We are working on removing all AngularJS from our code and vulnerabilities will go away when we complete the transition to Vue.js.
-- [CVE-2024-9506](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx) vulnerability in `vue`, an ReDoS vulnerability exploitable through inefficient regex evaluation in parseHTML function. The issue can cause excessive CPU usage but is not exploitable in the editor as we don't load untrusted HTML at runtime.
+No known vulnerabilities. :tada:
 
 ## Patches
 
 Here is a list of all patches after the release has been announced.
 
 ### Livingdocs Server Patches
+
 - [v296.2.61](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v296.2.61): fix(deps): automatically patch Node.js vulnerabilities
 - [v296.2.60](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v296.2.60): fix(retresco): Preserve document updatedAt when re-enriching
 - [v296.2.59](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v296.2.59): fix(deps): automatically patch Node.js vulnerabilities
@@ -407,7 +407,6 @@ Here is a list of all patches after the release has been announced.
 - [v296.2.9](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v296.2.9): fix(deps): update dependency file-type from 21.3.0 to 21.3.2 [security]
 - [v296.2.8](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v296.2.8): fix(media-library): Don't replace time in usage log reporting date
 - [v296.2.7](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v296.2.7): fix(image-collections): remove custom desktop/mobile create label for simplicity
-
 - [v296.2.6](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v296.2.6): fix(deps): update dependency fastify from 5.7.4 to 5.8.1 [security]
 - [v296.2.5](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v296.2.5): refactor: rename preserveDate to preserveUpdatedAt
 - [v296.2.4](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v296.2.4): refactor(image-rotation): retry logic and sanity checks
@@ -416,6 +415,7 @@ Here is a list of all patches after the release has been announced.
 - [v296.2.1](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v296.2.1): fix(deps): update dependency @livingdocs/framework from 32.12.6 to v32.12.7
 
 ### Livingdocs Editor Patches
+
 - [v123.10.73](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.10.73): fix(deps): update dependency nanoid to v5.1.16 [security]
 - [v123.10.72](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.10.72): fix(deps): update dependency sanitize-html from 2.17.4 to 2.17.5 [security]
 - [v123.10.71](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.10.71): fix(metadata): build image urls with crop and original dimensions
@@ -472,9 +472,7 @@ Here is a list of all patches after the release has been announced.
 - [v123.10.20](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.10.20): fix: request confirmation before archiving a group
 - [v123.10.19](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.10.19): fix: add scroll offset
 - [v123.10.18](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.10.18): fix(image-collections): remove specific mobile/desktop label after refactoring
-
 - [v123.10.17](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.10.17): fix(app navigation): Line wrapping
-
 - [v123.10.16](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.10.16): fix(deps): update dependency fastify from 5.7.4 to 5.8.1 [security]
 - [v123.10.15](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.10.15): fix(image-collections): prevent check of undefined
 - [v123.10.14](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.10.14): fix: add an early return guard if onDrag is not a function

--- a/content/operations/releases/release-2026-05.md
+++ b/content/operations/releases/release-2026-05.md
@@ -574,17 +574,15 @@ This release we have patched the following vulnerabilities in the Livingdocs Ser
 
 ### Livingdocs Editor
 
-We are aware of the following vulnerabilities in the Livingdocs Editor:
-
-- [CVE-2023-44270](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) vulnerability in `postcss`, it affects linters using PostCSS to parse external Cascading Style Sheets (CSS). It is not exploitable in the editor as we don't load untrusted external CSS at build time.
-- [CVE-2022-25844](https://github.com/advisories/GHSA-m2h2-264f-f486), [CVE-2022-25869](https://github.com/advisories/GHSA-prc3-vjfx-vhm9), [CVE-2023-26116](https://github.com/advisories/GHSA-2vrf-hf26-jrp5), [CVE-2023-26117](https://github.com/advisories/GHSA-2qqx-w9hr-q5gx), [CVE-2023-26118](https://github.com/advisories/GHSA-qwqh-hm9m-p5hr), [CVE-2024-8372](https://github.com/advisories/GHSA-m9gf-397r-hwpg), [CVE-2024-8373](https://github.com/advisories/GHSA-mqm9-c95h-x2p6), [CVE-2024-21490](https://github.com/advisories/GHSA-4w4v-5hc9-xrr2), [CVE-2025-0716](https://github.com/advisories/GHSA-j58c-ww9w-pwp5) are all AngularJS vulnerabilities that don't have a patch available. We are working on removing all AngularJS from our code and vulnerabilities will go away when we complete the transition to Vue.js.
-- [CVE-2024-9506](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx) vulnerability in `vue`, an ReDoS vulnerability exploitable through inefficient regex evaluation in parseHTML function. The issue can cause excessive CPU usage but is not exploitable in the editor as we don't load untrusted HTML at runtime.
+This release we haven't patched any vulnerabilities in the Livingdocs Editor.
+There are no known vulnerabilities. :tada:
 
 ## Patches
 
 Patches typically fix bugs and apply improvements within the current release. Keeping your deployment up-to-date with the latest patch version means you benefit from those fixes. No explicit action is required per patch — bumping the version is enough.
 
 ### Livingdocs Server Patches
+
 - [v301.1.38](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.38): fix(deps): automatically patch Node.js vulnerabilities
 - [v301.1.37](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.37): fix(retresco): Preserve document updatedAt when re-enriching
 - [v301.1.36](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.36): fix(deps): automatically patch Node.js vulnerabilities
@@ -601,7 +599,6 @@ Patches typically fix bugs and apply improvements within the current release. Ke
 - [v301.1.25](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.25): fix(media-library): add file extension to image downloads in Chrome and Edge
 - [v301.1.24](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.24): fix(deps): bump @opentelemetry to ^0.219 to remove vulnerable protobufjs 8.0.1
 - [v301.1.23](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.23): fix: comply with demo platform code rules
-
 - [v301.1.22](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.22): fix: Trigger release after deps update
 - [v301.1.21](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.21): fix(deps): update livingdocs-patch
 - [v301.1.20](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.20): fix: remove server-lib workspace
@@ -620,15 +617,13 @@ Patches typically fix bugs and apply improvements within the current release. Ke
 - [v301.1.7](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.7): fix(deps): update dependency ws from 8.20.0 to 8.20.1 [security]
 - [v301.1.6](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.6): fix(migrations): Only generate statistics and references with content
 - [v301.1.5](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.5): test: Adjust transform tests to account for serialized component IDs
-
 - [v301.1.4](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.4): fix(image-collections): add breaking change to not use any dashboards with handle imageCollections
 - [v301.1.3](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.3): fix(blob-store): suppress late AbortError from Azure download streams
-
 - [v301.1.2](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.2): fix(deps): update dependency @opentelemetry/sdk-node from 0.215.0 to 0.217.0 [security]
-
 - [v301.1.1](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v301.1.1): fix(release-2026-05): Update framework to v34.0.3 (release-2026-05 tag)
 
 ### Livingdocs Editor Patches
+
 - [v123.21.46](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.46): fix(deps): update dependency pdfjs-dist from 5.7.284 to 6.2.108 [security]
 - [v123.21.45](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.45): fix(deps): update dependency sanitize-html from 2.17.4 to 2.17.5 [security]
 - [v123.21.44](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.44): refactor(document-inbox): Use clearer names in drag auto-scroll
@@ -650,7 +645,6 @@ Patches typically fix bugs and apply improvements within the current release. Ke
 - [v123.21.28](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.28): fix: trigger a new release version
 - [v123.21.27](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.27): fix(deps): ship angular, vue and vue-demi TuxCare forks as direct deps
 - [v123.21.26](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.26): fix: show component groups with translated labels
-
 - [v123.21.25](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.25): fix(media-library): Prevent li-metadata-translations save on open
 - [v123.21.24](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.24): fix(deps): update livingdocs-patch from 34.0.5 to v34.0.6
 - [v123.21.23](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.23): fix(deps): update dependency js-yaml from 4.1.1 to 4.2.0 [security]
@@ -668,13 +662,10 @@ Patches typically fix bugs and apply improvements within the current release. Ke
 - [v123.21.11](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.11): fix(project-config): show kordiam form and nav
 - [v123.21.10](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.10): fix(drafts): Reload editor when document contentType changes via remote update
 - [v123.21.9](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.9): fix(deps): update dependency sanitize-html from 2.17.3 to 2.17.4 [security]
-
 - [v123.21.8](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.8): fix(image-collections): add imageCollections as coreItem instead of enrichedItem
 - [v123.21.7](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.7): fix(image-collections): use container's filtered items for move position
-
 - [v123.21.6](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.6): fix(deps): automatically patch Node.js vulnerabilities
 - [v123.21.5](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.5): fix(includes): expose params getter to maintain public API for tests
-
 - [v123.21.4](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.4): fix: hide images count earlier to prevent overlap with batch actions
 - [v123.21.3](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.3): fix(media-library): Hide state of media source items
 - [v123.21.2](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v123.21.2): fix(publish-control): Use correct publishControlMode for labels

--- a/content/operations/releases/release-2026-07.md
+++ b/content/operations/releases/release-2026-07.md
@@ -528,17 +528,15 @@ There are no known vulnerabilities. :tada:
 
 ### Livingdocs Editor
 
-We are aware of the following vulnerabilities in the Livingdocs Editor:
-
-- [CVE-2023-44270](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) vulnerability in `postcss`, it affects linters using PostCSS to parse external Cascading Style Sheets (CSS). It is not exploitable in the editor as we don't load untrusted external CSS at build time.
-- [CVE-2022-25844](https://github.com/advisories/GHSA-m2h2-264f-f486), [CVE-2022-25869](https://github.com/advisories/GHSA-prc3-vjfx-vhm9), [CVE-2023-26116](https://github.com/advisories/GHSA-2vrf-hf26-jrp5), [CVE-2023-26117](https://github.com/advisories/GHSA-2qqx-w9hr-q5gx), [CVE-2023-26118](https://github.com/advisories/GHSA-qwqh-hm9m-p5hr), [CVE-2024-8372](https://github.com/advisories/GHSA-m9gf-397r-hwpg), [CVE-2024-8373](https://github.com/advisories/GHSA-mqm9-c95h-x2p6), [CVE-2024-21490](https://github.com/advisories/GHSA-4w4v-5hc9-xrr2), [CVE-2025-0716](https://github.com/advisories/GHSA-j58c-ww9w-pwp5) are all AngularJS vulnerabilities that don't have a patch available. We are working on removing all AngularJS from our code and vulnerabilities will go away when we complete the transition to Vue.js.
-- [CVE-2024-9506](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx) vulnerability in `vue`, an ReDoS vulnerability exploitable through inefficient regex evaluation in parseHTML function. The issue can cause excessive CPU usage but is not exploitable in the editor as we don't load untrusted HTML at runtime.
+This release we haven't patched any vulnerabilities in the Livingdocs Editor.
+There are no known vulnerabilities. :tada:
 
 ## Patches
 
 Here is a list of all patches after the release has been announced.
 
 ### Livingdocs Server Patches
+
 - [v308.1.20](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v308.1.20): fix(deps): automatically patch Node.js vulnerabilities
 - [v308.1.19](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v308.1.19): fix(indexing): Make indexing consumer stop less noisy on server shutdown
 - [v308.1.18](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v308.1.18): fix(retresco): Preserve document updatedAt when re-enriching
@@ -554,13 +552,12 @@ Here is a list of all patches after the release has been announced.
 - [v308.1.8](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v308.1.8): fix(includes): speed up regression test
 - [v308.1.7](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v308.1.7): fix(deps): automatically patch Node.js vulnerabilities
 - [v308.1.6](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v308.1.6): fix(image-processing): Avoid truncated flag for exact file size match
-
 - [v308.1.5](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v308.1.5): fix(media-library): add file extension to image downloads in Chrome and Edge
-
 - [v308.1.4](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v308.1.4): fix(license-profile): allow internal usagePurposes without recordUsageLogEntry
 - [v308.1.3](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v308.1.3): fix(print): Renumber huGO print breaking change to LIBREAKING071
 
 ### Livingdocs Editor Patches
+
 - [v126.1.22](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.22): fix(deps): update dependency pdfjs-dist from 6.1.200 to 6.2.108 [security]
 - [v126.1.21](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.21): fix(metadata): build image urls with crop and original dimensions
 - [v126.1.20](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.20): fix(multilist-editor): Use correct permission to enable multilist editor
@@ -572,12 +569,10 @@ Here is a list of all patches after the release has been announced.
 - [v126.1.14](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.14): fix(draft-storage): Persist unsaved content while saving is disabled
 - [v126.1.13](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.13): fix(dates): add nb-NO and nn-NO to relative-time locales
 - [v126.1.12](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.12): fix(metadata): report initial form validity on mount
-
 - [v126.1.11](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.11): fix: toggle include overrides of only focused component
 - [v126.1.10](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.10): fix: keep drag scroll working after window resize
 - [v126.1.9](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.9): fix(search): Stop cheat sheet flyout from being pushed below the button
 - [v126.1.8](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.8): fix(media-library): add standard cost class translation to license profile form
-
 - [v126.1.7](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.7): fix(media-library): hide license profile tag when profiles not configured
 - [v126.1.6](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.6): fix(media-library): hide media state badge on empty image placeholder
 - [v126.1.5](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v126.1.5): fix(metadata): initialize named crops once the image is available

--- a/content/operations/releases/release-2026-09.md
+++ b/content/operations/releases/release-2026-09.md
@@ -64,6 +64,7 @@ These are the release notes of the upcoming release (pull requests merged to the
 - :fire: Integration against the upcoming release (currently `main` branch) is at your own risk
 
 ## PRs to Categorize
+
 - [chore(deps): update aws-sdk from 3.1110.0 to v3.1111.0 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/9894)
 - [Replace the image cropping tool with Pintura](https://github.com/livingdocsIO/livingdocs-editor/pull/11359)
 - [chore(deps): update dependency mocha from 12.0.0-rc.5 to v12.0.0-rc.6 (main)](https://github.com/livingdocsIO/livingdocs-editor/pull/11455)
@@ -206,11 +207,7 @@ This release we have patched the following vulnerabilities in the Livingdocs Edi
 
 - TBD
 
-We are aware of the following vulnerabilities in the Livingdocs Editor:
-
-- [CVE-2023-44270](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) vulnerability in `postcss`, it affects linters using PostCSS to parse external Cascading Style Sheets (CSS). It is not exploitable in the editor as we don't load untrusted external CSS at build time.
-- [CVE-2022-25844](https://github.com/advisories/GHSA-m2h2-264f-f486), [CVE-2022-25869](https://github.com/advisories/GHSA-prc3-vjfx-vhm9), [CVE-2023-26116](https://github.com/advisories/GHSA-2vrf-hf26-jrp5), [CVE-2023-26117](https://github.com/advisories/GHSA-2qqx-w9hr-q5gx), [CVE-2023-26118](https://github.com/advisories/GHSA-qwqh-hm9m-p5hr), [CVE-2024-8372](https://github.com/advisories/GHSA-m9gf-397r-hwpg), [CVE-2024-8373](https://github.com/advisories/GHSA-mqm9-c95h-x2p6), [CVE-2024-21490](https://github.com/advisories/GHSA-4w4v-5hc9-xrr2), [CVE-2025-0716](https://github.com/advisories/GHSA-j58c-ww9w-pwp5) are all AngularJS vulnerabilities that don't have a patch available. We are working on removing all AngularJS from our code and vulnerabilities will go away when we complete the transition to Vue.js.
-- [CVE-2024-9506](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx) vulnerability in `vue`, an ReDoS vulnerability exploitable through inefficient regex evaluation in parseHTML function. The issue can cause excessive CPU usage but is not exploitable in the editor as we don't load untrusted HTML at runtime.
+No known vulnerabilities. :tada:
 
 ## Patches
 


### PR DESCRIPTION
Relations:
- Related PR: https://github.com/livingdocsIO/livingdocs-editor/pull/10667
