### PR TITLE
Require license profiles to be enabled explicitly

### DIFF
--- a/content/guides/media-library/license-profiles/index.md
+++ b/content/guides/media-library/license-profiles/index.md
@@ -15,7 +15,7 @@ Two building blocks work together:
 - **Usage purpose**: a named publication context (Web, Print, Newsletter, ...). A document resolves to exactly one purpose via its content type.
 - **License profile**: a color-coded set of rules, one rule per usage purpose. Assigned to a media library entry through the [`li-license-profile`]({{< ref "/reference/document/metadata/plugins/li-license-profile" >}}) metadata plugin.
 
-The feature is opt-in. It only activates for media types that have the `li-license-profile` metadata plugin configured, and only when profiles are present in the project config. Existing setups are unaffected.
+The feature is opt-in. License profiles are only enforced when `licenseProfiles.enabled` is set to `true` and profiles are configured. Media types with the `li-license-profile` metadata plugin are then checked for whether they may be published in a document. Media types without the plugin are not restricted.
 
 ## How License Profiles Work
 
@@ -127,8 +127,8 @@ Define the profiles in the project config:
 // project config
 mediaCenter: {
   licenseProfiles: {
-    // Switches enforcement on. While false, profiles can be assigned to media but
-    // never block publishing. See "Enabling Enforcement" below.
+    // Switches enforcement on. Defaults to false. While false, profiles can be
+    // assigned to media but never block publishing. See "Enabling Enforcement" below.
     enabled: false,
     // Required as soon as one profile has approvalRequired: true.
     // Must match the handle of a li-task-v2 metadata property (see below).
@@ -252,10 +252,12 @@ That is the whole setup. No hook registration call is needed: once profiles are 
 
 ### Enabling Enforcement
 
-`licenseProfiles.enabled` controls whether profiles are enforced:
+`licenseProfiles.enabled` controls whether profiles are enforced. It defaults to `false`, so enforcement has to be switched on deliberately:
 
-- **`false`**: profiles can be configured and assigned to media, but they never affect publishing. Media without a profile (or with an unknown or uncovered profile) does not block publication, and no approval tasks are requested. The license profiles can manually be set in the image metadata.
-- **`true`**: the publish gate and approval workflow described above are in effect. License profiles are shown in the UI.
+- **`false`** (the default): profiles can be configured and assigned to media, but they never affect publishing. Media without a profile (or with an unknown or uncovered profile) does not block publication, and no approval tasks are requested. The license profiles can manually be set in the image metadata.
+- **`true`**: the publish gate and approval workflow described above are in effect. License indicators and warnings are shown in the editor.
+
+In {{< release "release-2026-07" >}} the property defaulted to `true`.
 
 ## Constraints
 

--- a/content/operations/releases/release-2026-09.md
+++ b/content/operations/releases/release-2026-09.md
@@ -183,6 +183,43 @@ In the editor config, an `imageCrop` key under `editor`. Search for `imageCrop`.
 
 Remove the `editor.imageCrop` block and its options (`maxArea`, `showSurroundingImage`, `surroundingImageOpacity`, and `zoomStep`) from all editor configs and test fixtures. No replacement is needed.
 
+### Changed Default of `licenseProfiles.enabled`
+
+The project config property `mediaCenter.licenseProfiles.enabled` now defaults to `false` instead of `true`. License profiles are now only enforced when the feature is explicitly enabled and at least one profile is configured.
+
+Projects that configured license profiles without the property were enforcing them implicitly. After the upgrade, those projects silently stop blocking publication, stop requesting approval tasks, and stop warning about license violations while editing. See the [License Profiles]({{< ref "/guides/media-library/license-profiles#enabling-enforcement" >}}) guide for what enforcement covers.
+
+#### Detect
+
+In the project config, `mediaCenter.licenseProfiles` has a non-empty `profiles` array and no `enabled` key. Search for `licenseProfiles` and check each hit for an `enabled` child property.
+
+```js
+// project config
+mediaCenter: {
+  licenseProfiles: {
+    profiles: [
+      /* ... */
+    ]
+  }
+}
+```
+
+#### Fix
+
+Set `mediaCenter.licenseProfiles.enabled` to `true` to keep the behavior from before the upgrade. Projects that already set the property explicitly need no change.
+
+```js
+// project config
+mediaCenter: {
+  licenseProfiles: {
+    enabled: true,
+    profiles: [
+      /* ... */
+    ]
+  }
+}
+```
+
 ## Deprecations :warning:
 
 ## Features :gift:

--- a/content/reference/project-config/media-center.md
+++ b/content/reference/project-config/media-center.md
@@ -97,7 +97,7 @@ Each purpose supports:
 
 `mediaCenter.licenseProfiles` defines the license profiles that can be assigned to media library entries and the task used for license approvals. Please see the [License Profiles]({{< ref "/guides/media-library/license-profiles" >}}) guide for the full configuration and behavior.
 
-- `enabled` (optional, defaults to `true`): switches enforcement on. When `false`, profiles can be configured and assigned to media, but they do not affect publishing — unprofiled media never blocks publication and no approval tasks are requested. Set it to `false` while your existing media is still being assigned its profiles, so that a migration of the existing stock cannot lock up the newsroom in the meantime.
+- `enabled` (optional, defaults to `false`): turns enforcement on. When `false`, you can assign profiles to media, but publishing is not affected and no approval tasks are created. Keep it off until all your existing media has a profile. In {{< release "release-2026-07" >}} it defaulted to `true`.
 
 ## Usage Log
 


### PR DESCRIPTION
Relations:

- Resolves: https://app.notion.com/p/livingdocsio/Add-optional-enforcement-to-License-profiles-Follow-Up-release-2026-07-3adc559571d68002bbabc81b5da4d5f5
- Related PRs: https://github.com/livingdocsIO/livingdocs-server/pull/9919, https://github.com/livingdocsIO/livingdocs-editor/pull/11474

# Description

`mediaCenter.licenseProfiles.enabled` now defaults to `false`. Before, license profiles were enforced unless you set `enabled: false`. Now they are off unless you set `enabled: true`. If your project has license profiles configured but has no flag, add `enabled: true` to keep them enforced.
