### PR TITLE
Warn about Elasticsearch indices created before 2024-04

### DIFF
--- a/content/operations/releases/release-2026-07.md
+++ b/content/operations/releases/release-2026-07.md
@@ -110,7 +110,17 @@ livingdocs-server migrate up
 
 This release adds Norwegian language support (Bokmål `nb` and Nynorsk `nn`) across the drafts, publications, and media library indices, and language-aware text fields plus a German decompounder to the media library.
 
-The change is backwards compatible: until the indices are recreated, the new language-specific fields are silently skipped and search keeps working as before.
+The change is backwards compatible for indices created with a server from 2024-04 or later: until the indices are recreated, the new language-specific fields are silently skipped and search keeps working as before.
+
+{{< warning >}}
+Indices created with a server older than 2024-04 do not carry the `exact` analyzer in their settings, and the mapping changes in this release reference it. Elasticsearch rejects the mapping patch with `analyzer [exact] has not been configured in mappings`, and index initialization gives up after five minutes of retries, so the index stops being updated.
+
+An index that lists `german_html_analyzer` but no `exact` is affected and has to be recreated:
+
+```sh
+curl -s "$ELASTIC_URL/<index>/_settings?filter_path=**.analysis.analyzer"
+```
+{{< /warning >}}
 
 {{< info >}}
 To enable Norwegian language support, the affected Elasticsearch indices need to be


### PR DESCRIPTION
Relations:

- Related PRs: https://github.com/livingdocsIO/livingdocs-server/pull/9947

# Description

Indices created with a server older than 2024-04 have no `exact` analyzer in their settings, and the mapping changes in release-2026-07 reference it. Elasticsearch rejects the mapping patch, index initialization gives up after five minutes of retries and the index stops being updated. The release notes claimed the change was backwards compatible for every index, which held only for indices created after that date.
