### PR TITLE
Update stale TRN system requirements

### DIFF
--- a/.claude/skills/cleanup-trn/SKILL.md
+++ b/.claude/skills/cleanup-trn/SKILL.md
@@ -170,29 +170,70 @@ Some entries may only have a GHSA identifier (no CVE) — that's fine, just omit
 
 Replace each `- TBD` placeholder with the extracted list. If a subsection has no patches, leave its `- TBD` in place. If neither subsection has any patches, also add a checkbox to the PR's `## Open Tasks` section (do not mention it in the changelog).
 
-### 5f. Review the System Requirements versions
+### 5f. Fill in the System Requirements versions
 
-The System Requirements live in the file's **frontmatter** under `systemRequirements:` — a `suggested:` and a `minimal:` list, each with a `version` for Node, NPM, Postgres, Elasticsearch, OpenSearch, Redis, the two Livingdocs Docker images, and Browser Support. The release bot copies these forward from the previous release unchanged, so they must be reviewed each cycle for version bumps.
+The System Requirements live in the file's **frontmatter** under `systemRequirements:` — a `suggested:` and a `minimal:` list, each with a `version` for Node, NPM, Postgres, Elasticsearch, OpenSearch, Redis, Valkey, the two Livingdocs Docker images, and Browser Support. The `{{< system-versions >}}` shortcodes in the body render from this block, so edit the frontmatter and nothing else.
 
-Run these three checks, then confirm with the user before changing anything:
+The template sets every value to `TBD`. Fill them all in — a `TBD` still there on announcement day blocks the release. If a row already holds a real version, an earlier pass filled it in; verify it against the source of truth below rather than trusting it.
 
-1. **Diff against the previous release.** Compare this release's `systemRequirements` block against the previous release's (read in Step 1). Note which values carried forward unchanged and which differ.
-2. **Cross-check Node & NPM against the server's engines.** Use the GitHub MCP to read `package.json` (the `engines` field) and `.nvmrc` from `livingdocsIO/livingdocs-server`:
-   - `engines.node` / `engines.npm` lower bounds define the **minimal** Node / NPM.
-   - `.nvmrc` is the development Node version and is a good signal for the **suggested** Node.
-   - Flag any mismatch — e.g. engines allow `>=26` but suggested Node still says `24`.
-3. **Scan this release's own content for version changes.** Re-read the `## Features`, `## Breaking Changes`, and `## Deprecations` sections for any entry that changes a supported version — e.g. "Officially Support Node.js vXX", "Drop support for Postgres XX", or a browser-support bump. Each such entry implies a matching change in `suggested` or `minimal`.
+**Timing.** These versions are only decidable once the release month has begun: the browser boundary is the end of the preceding month, and a Node major's LTS date can fall in that same window. On a mid-cycle pass, leave the rows as `TBD` and add `- [ ] Fill in the System Requirements` to the PR's `## Open Tasks` instead of guessing.
 
-Present the findings and ask:
+#### Suggested versions
 
-> "System Requirements review for `<release-handle>`:
-> - <carried forward unchanged from previous release / differences found>
-> - <Node & NPM vs server engines: match or mismatch>
+| Row                                                | Source of truth                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Node                                               | The highest major CI actually tests on the release branch — the `test-node-<major>` pipelines in `git -C <livingdocs-server> show origin/<release-handle>:.drone.yml` — that is _also_ Active LTS on announcement day per `curl -s https://raw.githubusercontent.com/nodejs/Release/main/schedule.json`. Both have to hold: CI usually gains a major months before it reaches LTS, and a major with no pipeline and no published base image is not thoroughly tested whatever its LTS status. |
+| NPM                                                | The major bundled with the suggested Node: `curl -s https://nodejs.org/dist/index.json`, read `npm` for that version.                                                                                                                                                                                                                                                                                                                                                                         |
+| Postgres, Redis, Valkey, Elasticsearch, OpenSearch | The newest version CI actually runs on the release branch: `git -C <livingdocs-server> show origin/<release-handle>:.drone.yml`. Use this rather than the upstream GA date — the image has to exist and be in the pipeline before we recommend it.                                                                                                                                                                                                                                            |
+| Docker images                                      | `livingdocs/server-base:<suggested Node major>` and `livingdocs/editor-base:<same major>`. Confirm both tags exist — the editor image is sometimes published later than the server one: `curl -s "https://hub.docker.com/v2/repositories/livingdocs/server-base/tags?page_size=50"`, and the same for `editor-base`. If either is missing, the major is not ready to be suggested.                                                                                                            |
+| Browser Support                                    | See the browser rule below.                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+
+#### Minimal versions
+
+| Row                                                | Source of truth                                                                                                                                                                                                                                                   |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Node                                               | The lowest version `engines.node` allows on the release branch, which must match the lowest `test-node-<major>` pipeline in `.drone.yml`. Server and editor must agree; if the three disagree, stop and report it rather than picking one.                        |
+| NPM                                                | The major bundled with that minimal Node — not `engines.npm`, which has lagged behind before.                                                                                                                                                                     |
+| Postgres, Redis, Valkey, Elasticsearch, OpenSearch | `app/deprecations.js` and `app/breaking-changes.js` on the release branch. A minimum moves only in the release carrying the `LIBREAKING…` entry that drops the old version. A `LIDEP…` entry names the future release where it will move and changes nothing yet. |
+| Docker images                                      | `:<minimal Node major>` for both images.                                                                                                                                                                                                                          |
+| Browser Support                                    | The same rule as suggested, one year earlier.                                                                                                                                                                                                                     |
+
+#### Browser rule
+
+Suggested is the last stable version available on the final day of the month _before_ the release month; minimal is that same boundary one year earlier. For `release-2026-07`, suggested Chrome is 150 (released 2026-06-30), not 151 from July; minimal Chrome is 138 (released 2025-06-24).
+
+Look each browser up separately — their trains don't line up:
+
+- **Chrome:** `curl -s "https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=<major>"`, field `stable_date`
+- **Firefox:** `curl -s "https://whattrainisitnow.com/api/release/schedule/?version=<major>"`, field `release`
+- **Safari:** `curl -s https://support.apple.com/en-us/100100` — Apple's security-releases list, each entry dated
+- **Edge:** pin to the Chrome major. Edge ships two to five days after Chrome, so at a month boundary its own date sometimes falls just outside; keep the numbers aligned regardless.
+
+Write Safari as it ships (`18.6`, `26.2`) and the rest as bare majors.
+
+#### Check against the previous release
+
+Before moving on, diff your rows against the previous release's `systemRequirements` block. No row may go _backwards_: a suggested or minimal version lower than the previous release's is almost always a value copied from a stale template, not a real change. Minimums in particular only ever rise, and only in the release that carries the `LIBREAKING…` entry dropping the old version.
+
+If a row does go down and you can't name the reason — we stopped testing that version, we pulled the image — treat it as a copy-paste error and go back to the source of truth. This has bitten us: suggested Postgres was correct at 18 in `release-2026-01`, then sat at 17 for the next three releases because each one inherited a stale value.
+
+Do not copy your finished block into `_release-template.md`. The template deliberately holds `TBD` in every row so that each release has to derive its own versions.
+
+#### Cross-check this release's own content
+
+Re-read this release's `## Features`, `## Breaking Changes` and `## Deprecations` sections for any entry that changes a supported version — "Officially Support Node.js vXX", "Drop support for Postgres XX", a browser-support bump. Each such entry implies a matching change here, and a mismatch means one of the two is wrong.
+
+Present what you derived and confirm before writing:
+
+> "System Requirements for `<release-handle>`:
+>
+> - Suggested: <rows that change, with the source that decided each>
+> - Minimal: <rows that change, with the source that decided each>
 > - <version changes announced in this release, if any>
 >
-> Should I update any Suggested or Minimal values? (yes, with the changes — or no, leave as is)"
+> Apply these?"
 
-Apply only the changes the user confirms, editing the `systemRequirements` frontmatter. **Never bump a value on your own** — these are support commitments, so always confirm first.
+**Never bump a value on your own** — these are support commitments, so always confirm first.
 
 ## Step 6: Commit, push, and open PR
 

--- a/.claude/skills/update-release-metadata/SKILL.md
+++ b/.claude/skills/update-release-metadata/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: update-release-metadata
-description: Prepares a GitHub PR to update Livingdocs release metadata on announcement day. Use this skill when the user mentions updating release metadata, announcement day, a release going live, or wants to prepare the metadata PR for a new release (e.g. "release-2026-05 is being announced today", "update the release metadata", "prepare announcement day PR"). This skill handles the full git workflow: branch creation, file edits, commit, push, and PR creation.
+description: Prepares a GitHub PR to update Livingdocs release metadata on announcement day. Use this skill when the user mentions updating release metadata, announcement day, a release going live, or wants to prepare the metadata PR for a new release (e.g. "release-2026-05 is being announced today", "update the release metadata", "prepare announcement day PR"). This skill handles the full git workflow - branch creation, file edits, commit, push, and PR creation. The TRN content itself, system requirements included, is handled by cleanup-trn beforehand.
 ---
 
 # Update Release Metadata
 
-On announcement day, the release state machine needs to advance: a new release moves from `upcoming` to `current`, the previous current becomes `maintained`, and the oldest maintained becomes `legacy`. This skill handles all the file edits and git workflow.
+On announcement day, the release state machine needs to advance: a new release moves from `upcoming` to `current`, the previous current becomes `maintained`, and the oldest maintained becomes `legacy`. This skill handles all the file edits and git workflow. It is deliberately lightweight — the content work, system requirements included, belongs to `cleanup-trn` and should already be done by now.
 
 ## Step 1: Identify the release
 
@@ -108,6 +108,8 @@ Apply the same logical changes for all three releases in their respective JSON o
 "maintained": false,
 "legacy": true,
 ```
+
+Finally, check that the new release's `systemRequirements` block holds no `TBD` rows. Filling them in is `cleanup-trn` step 5f's job and should have happened in the final cleanup pass; a `TBD` reaching a current release is a blocker, so stop and finish that first rather than deriving versions here.
 
 ## Step 4: Commit
 

--- a/content/operations/releases/_release-template.md
+++ b/content/operations/releases/_release-template.md
@@ -15,29 +15,31 @@ header:
 systemRequirements:
   suggested:
     - name: Node
-      version: 24
+      version: 26
     - name: NPM
       version: 11
     - name: Postgres
-      version: 17
+      version: 18
     - name: Elasticsearch
       version: 9
     - name: OpenSearch
       version: 3
     - name: Redis
       version: 8
+    - name: Valkey
+      version: 9
     - name: Livingdocs Server Docker Image
-      version: livingdocs/server-base:24
+      version: livingdocs/server-base:26
     - name: Livingdocs Editor Docker Image
-      version: livingdocs/editor-base:24
+      version: livingdocs/editor-base:26
     - name: Browser Support
-      version: Chrome >= 145, Edge >= 145, Firefox >= 148, Safari >= 26.3
+      version: Chrome >= 156, Edge >= 156, Firefox >= 159, Safari >= 27.0
 
   minimal:
     - name: Node
-      version: 22.17.1
+      version: 24
     - name: NPM
-      version: 10
+      version: 11
     - name: Postgres
       version: 14
     - name: Elasticsearch
@@ -45,13 +47,15 @@ systemRequirements:
     - name: OpenSearch
       version: 2
     - name: Redis
-      version: 6.2
+      version: 7.4
+    - name: Valkey
+      version: 7
     - name: Livingdocs Server Docker Image
-      version: livingdocs/server-base:22
+      version: livingdocs/server-base:24
     - name: Livingdocs Editor Docker Image
-      version: livingdocs/editor-base:22
+      version: livingdocs/editor-base:24
     - name: Browser Support
-      version: Chrome >= 138, Edge >= 138, Firefox >= 140, Safari >= 18.6
+      version: Chrome >= 143, Edge >= 143, Firefox >= 146, Safari >= 26.2
 ---
 
 ## Caveat :fire:

--- a/content/operations/releases/_release-template.md
+++ b/content/operations/releases/_release-template.md
@@ -15,47 +15,47 @@ header:
 systemRequirements:
   suggested:
     - name: Node
-      version: 26
+      version: TBD
     - name: NPM
-      version: 11
+      version: TBD
     - name: Postgres
-      version: 18
+      version: TBD
     - name: Elasticsearch
-      version: 9
+      version: TBD
     - name: OpenSearch
-      version: 3
+      version: TBD
     - name: Redis
-      version: 8
+      version: TBD
     - name: Valkey
-      version: 9
+      version: TBD
     - name: Livingdocs Server Docker Image
-      version: livingdocs/server-base:26
+      version: TBD
     - name: Livingdocs Editor Docker Image
-      version: livingdocs/editor-base:26
+      version: TBD
     - name: Browser Support
-      version: Chrome >= 156, Edge >= 156, Firefox >= 159, Safari >= 27.0
+      version: TBD
 
   minimal:
     - name: Node
-      version: 24
+      version: TBD
     - name: NPM
-      version: 11
+      version: TBD
     - name: Postgres
-      version: 14
+      version: TBD
     - name: Elasticsearch
-      version: 8
+      version: TBD
     - name: OpenSearch
-      version: 2
+      version: TBD
     - name: Redis
-      version: 7.4
+      version: TBD
     - name: Valkey
-      version: 7
+      version: TBD
     - name: Livingdocs Server Docker Image
-      version: livingdocs/server-base:24
+      version: TBD
     - name: Livingdocs Editor Docker Image
-      version: livingdocs/editor-base:24
+      version: TBD
     - name: Browser Support
-      version: Chrome >= 143, Edge >= 143, Firefox >= 146, Safari >= 26.2
+      version: TBD
 ---
 
 ## Caveat :fire:

--- a/content/operations/releases/release-2026-03.md
+++ b/content/operations/releases/release-2026-03.md
@@ -19,7 +19,7 @@ systemRequirements:
     - name: NPM
       version: 11
     - name: Postgres
-      version: 17
+      version: 18
     - name: Elasticsearch
       version: 9
     - name: OpenSearch

--- a/content/operations/releases/release-2026-05.md
+++ b/content/operations/releases/release-2026-05.md
@@ -19,19 +19,21 @@ systemRequirements:
     - name: NPM
       version: 11
     - name: Postgres
-      version: 17
+      version: 18
     - name: Elasticsearch
       version: 9
     - name: OpenSearch
       version: 3
     - name: Redis
       version: 8
+    - name: Valkey
+      version: 9
     - name: Livingdocs Server Docker Image
       version: livingdocs/server-base:24
     - name: Livingdocs Editor Docker Image
       version: livingdocs/editor-base:24
     - name: Browser Support
-      version: Chrome >= 145, Edge >= 145, Firefox >= 148, Safari >= 26.3
+      version: Chrome >= 147, Edge >= 147, Firefox >= 150, Safari >= 26.4
 
   minimal:
     - name: Node
@@ -46,6 +48,8 @@ systemRequirements:
       version: 2
     - name: Redis
       version: 6.2
+    - name: Valkey
+      version: 7
     - name: Livingdocs Server Docker Image
       version: livingdocs/server-base:22
     - name: Livingdocs Editor Docker Image

--- a/content/operations/releases/release-2026-07.md
+++ b/content/operations/releases/release-2026-07.md
@@ -19,19 +19,21 @@ systemRequirements:
     - name: NPM
       version: 11
     - name: Postgres
-      version: 17
+      version: 18
     - name: Elasticsearch
       version: 9
     - name: OpenSearch
       version: 3
     - name: Redis
       version: 8
+    - name: Valkey
+      version: 9
     - name: Livingdocs Server Docker Image
       version: livingdocs/server-base:24
     - name: Livingdocs Editor Docker Image
       version: livingdocs/editor-base:24
     - name: Browser Support
-      version: Chrome >= 145, Edge >= 145, Firefox >= 148, Safari >= 26.3
+      version: Chrome >= 150, Edge >= 150, Firefox >= 152, Safari >= 26.5
 
   minimal:
     - name: Node
@@ -46,12 +48,14 @@ systemRequirements:
       version: 2
     - name: Redis
       version: 6.2
+    - name: Valkey
+      version: 7
     - name: Livingdocs Server Docker Image
       version: livingdocs/server-base:22
     - name: Livingdocs Editor Docker Image
       version: livingdocs/editor-base:22
     - name: Browser Support
-      version: Chrome >= 138, Edge >= 138, Firefox >= 140, Safari >= 18.6
+      version: Chrome >= 138, Edge >= 138, Firefox >= 140, Safari >= 18.5
 ---
 
 To get an overview about new functionality, read the [Release Notes](https://livingdocs.io/en/release-july-2026).

--- a/content/operations/releases/release-2026-09.md
+++ b/content/operations/releases/release-2026-09.md
@@ -19,19 +19,21 @@ systemRequirements:
     - name: NPM
       version: 11
     - name: Postgres
-      version: 17
+      version: 18
     - name: Elasticsearch
       version: 9
     - name: OpenSearch
       version: 3
     - name: Redis
       version: 8
+    - name: Valkey
+      version: 9
     - name: Livingdocs Server Docker Image
       version: livingdocs/server-base:24
     - name: Livingdocs Editor Docker Image
       version: livingdocs/editor-base:24
     - name: Browser Support
-      version: Chrome >= 145, Edge >= 145, Firefox >= 148, Safari >= 26.3
+      version: Chrome >= 152, Edge >= 152, Firefox >= 154, Safari >= 26.6
 
   minimal:
     - name: Node
@@ -45,13 +47,15 @@ systemRequirements:
     - name: OpenSearch
       version: 2
     - name: Redis
-      version: 6.2
+      version: 7.4
+    - name: Valkey
+      version: 7
     - name: Livingdocs Server Docker Image
       version: livingdocs/server-base:22
     - name: Livingdocs Editor Docker Image
       version: livingdocs/editor-base:22
     - name: Browser Support
-      version: Chrome >= 138, Edge >= 138, Firefox >= 140, Safari >= 18.6
+      version: Chrome >= 139, Edge >= 139, Firefox >= 142, Safari >= 18.6
 ---
 
 ## Caveat :fire:
@@ -64,6 +68,7 @@ These are the release notes of the upcoming release (pull requests merged to the
 - :fire: Integration against the upcoming release (currently `main` branch) is at your own risk
 
 ## PRs to Categorize
+
 - [Bump main to the next minor and update supported releases](https://github.com/livingdocsIO/livingdocs-editor/pull/11492)
 - [Bump main to the next minor and update supported releases](https://github.com/livingdocsIO/livingdocs-server/pull/9946)
 - [Improve Image Collections](https://github.com/livingdocsIO/livingdocs-editor/pull/11369)
@@ -306,6 +311,7 @@ No known vulnerabilities. :tada:
 Patches typically fix bugs and apply improvements within the current release. Keeping your deployment up-to-date with the latest patch version means you benefit from those fixes. No explicit action is required per patch — bumping the version is enough.
 
 ### Livingdocs Server Patches
+
 - [v312.0.7](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v312.0.7): fix: Deprecate Postgres 14
 - [v312.0.6](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v312.0.6): fix(deps): automatically patch Node.js vulnerabilities
 - [v312.0.5](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v312.0.5): fix(deps): update dependency nodemailer from 9.0.6 to 9.1.1 [security]
@@ -314,6 +320,7 @@ Patches typically fix bugs and apply improvements within the current release. Ke
 - [v312.0.2](https://github.com/livingdocsIO/livingdocs-server/releases/tag/v312.0.2): fix(imatrics-nlp): Add createConceptSuggestion to the API mock and match the getConcepts shape
 
 ### Livingdocs Editor Patches
+
 - [v128.1.6](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v128.1.6): fix(media-library): show open state on display settings dropdown
 - [v128.1.5](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v128.1.5): fix(webpack): Prevent dart-sass BOM from breaking scoped styles
 - [v128.1.4](https://github.com/livingdocsIO/livingdocs-editor/releases/tag/v128.1.4): test(dashboard): restore an article on the article management dashboard

--- a/content/operations/releases/release-2026-11.md
+++ b/content/operations/releases/release-2026-11.md
@@ -15,23 +15,25 @@ header:
 systemRequirements:
   suggested:
     - name: Node
-      version: 24
+      version: 26
     - name: NPM
       version: 11
     - name: Postgres
-      version: 17
+      version: 18
     - name: Elasticsearch
       version: 9
     - name: OpenSearch
       version: 3
     - name: Redis
       version: 8
+    - name: Valkey
+      version: 9
     - name: Livingdocs Server Docker Image
-      version: livingdocs/server-base:24
+      version: livingdocs/server-base:26
     - name: Livingdocs Editor Docker Image
-      version: livingdocs/editor-base:24
+      version: livingdocs/editor-base:26
     - name: Browser Support
-      version: Chrome >= 145, Edge >= 145, Firefox >= 148, Safari >= 26.3
+      version: Chrome >= 156, Edge >= 156, Firefox >= 159, Safari >= 27.0
 
   minimal:
     - name: Node
@@ -45,13 +47,15 @@ systemRequirements:
     - name: OpenSearch
       version: 2
     - name: Redis
-      version: 6.2
+      version: 7.4
+    - name: Valkey
+      version: 7
     - name: Livingdocs Server Docker Image
       version: livingdocs/server-base:22
     - name: Livingdocs Editor Docker Image
       version: livingdocs/editor-base:22
     - name: Browser Support
-      version: Chrome >= 138, Edge >= 138, Firefox >= 140, Safari >= 18.6
+      version: Chrome >= 142, Edge >= 142, Firefox >= 144, Safari >= 26.0
 ---
 
 ## Caveat :fire:
@@ -64,6 +68,7 @@ These are the release notes of the upcoming release (pull requests merged to the
 - :fire: Integration against the upcoming release (currently `main` branch) is at your own risk
 
 ## PRs to Categorize
+
 - [Patch vulnerabilities [main]](https://github.com/livingdocsIO/livingdocs-server/pull/9979)
 - [fix(deps): update dependency nodemailer from 9.1.1 to v10 (main)](https://github.com/livingdocsIO/livingdocs-server/pull/9992)
 - [Fix open-state styling on display settings dropdown button](https://github.com/livingdocsIO/livingdocs-editor/pull/11556)


### PR DESCRIPTION
I've updated the cleanup-trn skill and referenced it from the update-release-metadata skill so that keeping the versions up-to-date becomes part of the release routine.

## release-2026-03

- Suggested Postgres 17 → 18

## release-2026-05

- Suggested Postgres 17 → 18
- Suggested browsers → Chrome/Edge 147, Firefox 150, Safari 26.4
- Restored Valkey rows

## release-2026-07

- Suggested Postgres 17 → 18
- Suggested browsers → Chrome/Edge 150, Firefox 152, Safari 26.5
- Minimal Safari 18.6 → 18.5 (18.6 didn't exist until July 2025)
- Restored Valkey rows

## release-2026-09

- Suggested Postgres 17 → 18
- Suggested browsers → Chrome/Edge 152, Firefox 154, Safari 26.6
- Minimal Redis 6.2 → 7.4
- Minimal browsers → Chrome/Edge 139, Firefox 142 (Safari stays 18.6)
- Restored Valkey rows

## release-2026-11

- Suggested Node 24 → 26
- Suggested Postgres 17 → 18
- Suggested images :24 → :26
- Suggested browsers → Chrome/Edge 156, Firefox 159, Safari 27.0 (review later)
- Minimal Redis 6.2 → 7.4
- Minimal browsers → Chrome/Edge 142, Firefox 144, Safari 18.6 → 26.0
- Restored Valkey rows

## _release-template.md

- Restored Valkey rows
- Set all values to TBD to force us to review the values each time. The updated skill should handle this.
